### PR TITLE
Add success and failed constructors to CommandResult

### DIFF
--- a/packages/cqrs/CHANGELOG.md
+++ b/packages/cqrs/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 4.1.0
+
+- Add `success` and `failed` constructors in `CommandResult`.
+- Add `failed` getter in `CommandResult`.
+- Make `success` field in `CommandResult` a getter. This is compatible with how [the backend works](https://github.com/leancodepl/corelibrary/blob/a3a2a27b20e1cf684fb88aa55958721eff19c2bc/src/Domain/LeanCode.CQRS/CommandResult.cs#L11).
+- Deprecate `success` param in `CommandResult` constructor.
+
 # 4.0.0+2
 
 - Refresh pub listing.

--- a/packages/cqrs/LICENSE
+++ b/packages/cqrs/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2020 LeanCode Sp. z o.o.
+   Copyright 2021 LeanCode Sp. z o.o.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/packages/cqrs/lib/src/command_result.dart
+++ b/packages/cqrs/lib/src/command_result.dart
@@ -1,4 +1,4 @@
-// Copyright 2020 LeanCode Sp. z o.o.
+// Copyright 2021 LeanCode Sp. z o.o.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,25 +12,33 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'package:meta/meta.dart';
-
 import 'transport_types.dart';
 
 /// The result of running a [Command].
 class CommandResult {
-  const CommandResult(this.errors, {@required this.success})
-      : assert(errors != null),
-        assert(success != null);
+  const CommandResult(
+    this.errors, {
+    @Deprecated("Success is derived from the `errors` emptiness.") bool success,
+  }) : assert(errors != null);
+
+  /// Creates a success [CommandResult] without any errors.
+  const CommandResult.success() : errors = const [];
+
+  /// Creates a failed [CommandResult] and ensures it has errors.
+  CommandResult.failed(this.errors)
+      : assert(errors != null && errors.isNotEmpty);
 
   CommandResult.fromJson(Map<String, dynamic> json)
-      : success = json['WasSuccessful'] as bool,
-        errors = (json['ValidationErrors'] as List)
+      : errors = (json['ValidationErrors'] as List)
             .map((error) =>
                 ValidationError.fromJson(error as Map<String, dynamic>))
             .toList();
 
   /// Whether the command has succeeded.
-  final bool success;
+  bool get success => errors.isEmpty;
+
+  /// Whether the command has failed with [errors].
+  bool get failed => errors.isNotEmpty;
 
   /// Validation errors related to the data carried by the [Command].
   final List<ValidationError> errors;

--- a/packages/cqrs/pubspec.yaml
+++ b/packages/cqrs/pubspec.yaml
@@ -1,5 +1,5 @@
 name: cqrs
-version: 4.0.0+2
+version: 4.1.0
 homepage: https://github.com/leancodepl/flutter_corelibrary/tree/master/packages/cqrs
 repository: https://github.com/leancodepl/flutter_corelibrary
 description: >-

--- a/packages/cqrs/test/command_result_test.dart
+++ b/packages/cqrs/test/command_result_test.dart
@@ -7,7 +7,7 @@ void main() {
     const error2 = ValidationError(2, 'Second error');
 
     group('fields values are correct', () {
-      test('when constructed without errors with success', () {
+      test('when constructed without errors', () {
         const result = CommandResult([]);
 
         expect(result.success, true);
@@ -15,7 +15,7 @@ void main() {
         expect(result.errors, isEmpty);
       });
 
-      test('when constructed with errors without success', () {
+      test('when constructed with errors', () {
         const result = CommandResult([error1, error2]);
 
         expect(result.success, false);

--- a/packages/cqrs/test/command_result_test.dart
+++ b/packages/cqrs/test/command_result_test.dart
@@ -8,23 +8,41 @@ void main() {
 
     group('fields values are correct', () {
       test('when constructed without errors with success', () {
-        const result = CommandResult([], success: true);
+        const result = CommandResult([]);
 
         expect(result.success, true);
+        expect(result.failed, false);
         expect(result.errors, isEmpty);
       });
 
       test('when constructed with errors without success', () {
-        const result = CommandResult([error1, error2], success: false);
+        const result = CommandResult([error1, error2]);
 
         expect(result.success, false);
+        expect(result.failed, true);
         expect(result.errors, hasLength(2));
+      });
+
+      test('when constructed with success constructor', () {
+        const result = CommandResult.success();
+
+        expect(result.success, true);
+        expect(result.failed, false);
+        expect(result.errors, isEmpty);
+      });
+
+      test('when constructed with success constructor', () {
+        final result = CommandResult.failed([error1]);
+
+        expect(result.success, false);
+        expect(result.failed, true);
+        expect(result.errors, hasLength(1));
       });
     });
 
     group('hasError returns correct values', () {
       test('when there are some errors present', () {
-        const result = CommandResult([error1, error2], success: false);
+        const result = CommandResult([error1, error2]);
 
         expect(result.hasError(1), true);
         expect(result.hasError(2), true);
@@ -32,7 +50,7 @@ void main() {
       });
 
       test('when there are no errors present', () {
-        const result = CommandResult([], success: false);
+        const result = CommandResult([]);
 
         expect(result.hasError(1), false);
         expect(result.hasError(2), false);


### PR DESCRIPTION
- Add `success` and `failed` constructors in `CommandResult`.
- Add `failed` getter in `CommandResult`.
- Make `success` field in `CommandResult` a getter. This is compatible with how [the backend works](https://github.com/leancodepl/corelibrary/blob/a3a2a27b20e1cf684fb88aa55958721eff19c2bc/src/Domain/LeanCode.CQRS/CommandResult.cs#L11).
- Deprecate `success` param in `CommandResult` constructor.