### PR TITLE
login_client improvements

### DIFF
--- a/packages/login_client/CHANGELOG.md
+++ b/packages/login_client/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 1.1.0
 
-- OAauth2 `clientId` and `clientSecret` now default to an empty string.
+- OAuth2 `clientId` and `clientSecret` now default to an empty string.
 - Export `oauth2` `Credentials`, `AuthorizationException` and `ExpirationException`.
 - Add `onCredentialsChanged` stream to `LoginClient`.
 - Deprecate `credentialsChangedCallback`.

--- a/packages/login_client/CHANGELOG.md
+++ b/packages/login_client/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 1.1.0
 
-- OAuth2 `clientId` and `clientSecret` now default to an empty string.
+- OAuth2 `clientId` is now required.
+- OAuth2 `clientSecret` now defaults to an empty string.
 - Export `oauth2` `Credentials`, `AuthorizationException` and `ExpirationException`.
 - Add `onCredentialsChanged` stream to `LoginClient`.
 - Deprecate `credentialsChangedCallback`.

--- a/packages/login_client/CHANGELOG.md
+++ b/packages/login_client/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 1.1.0
+
+- OAauth2 `clientId` and `clientSecret` now default to an empty string.
+- Export `oauth2` `Credentials`, `AuthorizationException` and `ExpirationException`.
+- Add `onCredentialsChanged` stream to `LoginClient`.
+- Deprecate `credentialsChangedCallback`.
+
 # 1.0.0+1
 
 - Refresh pub listing.

--- a/packages/login_client/analysis_options.yaml
+++ b/packages/login_client/analysis_options.yaml
@@ -1,5 +1,9 @@
 include: package:lint/analysis_options_package.yaml
 
+analyzer:
+  exclude:
+    - test/.test_coverage.dart
+
 linter:
   rules:
     - sort_constructors_first

--- a/packages/login_client/lib/login_client.dart
+++ b/packages/login_client/lib/login_client.dart
@@ -15,6 +15,9 @@
 /// An OAuth2 compliant login client library.
 library login_client;
 
+export 'package:oauth2/oauth2.dart'
+    show Credentials, AuthorizationException, ExpirationException;
+
 export 'src/credentials_storage/credentials_storage.dart';
 export 'src/credentials_storage/in_memory_credentials_storage.dart';
 export 'src/login_client.dart';

--- a/packages/login_client/lib/src/oauth_settings.dart
+++ b/packages/login_client/lib/src/oauth_settings.dart
@@ -19,7 +19,7 @@ class OAuthSettings {
   /// Creates the [OAuthSettings].
   const OAuthSettings({
     @required this.authorizationUri,
-    this.clientId = '',
+    @required this.clientId,
     this.clientSecret = '',
     this.scopes = const [],
   })  : assert(clientId != null),

--- a/packages/login_client/lib/src/oauth_settings.dart
+++ b/packages/login_client/lib/src/oauth_settings.dart
@@ -19,10 +19,11 @@ class OAuthSettings {
   /// Creates the [OAuthSettings].
   const OAuthSettings({
     @required this.authorizationUri,
-    this.clientId,
-    this.clientSecret,
+    this.clientId = '',
+    this.clientSecret = '',
     this.scopes = const [],
-  });
+  })  : assert(clientId != null),
+        assert(clientSecret != null);
 
   /// The [`authorization endpoint`](https://tools.ietf.org/html/rfc6749#section-3.1)
   /// from the RFC 6749.

--- a/packages/login_client/pubspec.yaml
+++ b/packages/login_client/pubspec.yaml
@@ -1,5 +1,5 @@
 name: login_client
-version: 1.0.0+1
+version: 1.1.0
 homepage: https://github.com/leancodepl/flutter_corelibrary/tree/master/packages/login_client
 repository: https://github.com/leancodepl/flutter_corelibrary
 description: >-
@@ -17,7 +17,6 @@ dependencies:
   oauth2: ^1.6.3
 
 dev_dependencies:
-  fake_async: ^1.1.0
   lint: ^1.3.0
   mockito: ^4.1.3
   test: ^1.15.7

--- a/packages/login_client/pubspec.yaml
+++ b/packages/login_client/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
   oauth2: ^1.6.3
 
 dev_dependencies:
+  fake_async: ^1.1.0
   lint: ^1.3.0
   mockito: ^4.1.3
   test: ^1.15.7

--- a/packages/login_client_flutter/CHANGELOG.md
+++ b/packages/login_client_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.0.1
+
+- Fix reading null credentials.
+
 # 1.0.0
 
 - First release.

--- a/packages/login_client_flutter/lib/src/flutter_secure_credentials_storage.dart
+++ b/packages/login_client_flutter/lib/src/flutter_secure_credentials_storage.dart
@@ -27,6 +27,9 @@ class FlutterSecureCredentialsStorage implements CredentialsStorage {
   @override
   Future<Credentials> read() async {
     final json = await _storage.read(key: _key);
+    if (json == null) {
+      return null;
+    }
 
     try {
       return Credentials.fromJson(json);

--- a/packages/login_client_flutter/pubspec.yaml
+++ b/packages/login_client_flutter/pubspec.yaml
@@ -1,5 +1,5 @@
 name: login_client_flutter
-version: 1.0.0
+version: 1.0.1
 homepage: https://github.com/leancodepl/flutter_corelibrary/tree/master/packages/login_client_flutter
 repository: https://github.com/leancodepl/flutter_corelibrary
 description: >-


### PR DESCRIPTION
After using this library in a production app, there were few issues discovered. This Pull Request fixes them.

Also, I went back to the `onCredentialsChanged` stream in the `LoginClient` class as it was in the 0.* versions of the login_client library. It's just much easier for the developer and cleaner to use stream instead of passing a callback that the developer would have to prospectively somehow reach from other parts of the code.

**login_client**

- OAauth2 `clientId` and `clientSecret` now default to an empty string.
- Export `oauth2` `Credentials`, `AuthorizationException` and `ExpirationException`.
- Add `onCredentialsChanged` stream to `LoginClient`.
- Deprecate `credentialsChangedCallback`.

**login_client_flutter**

- Fix reading null credentials.

Closes #11.