### PR TITLE
Downgrade login_client's meta dependency

### DIFF
--- a/packages/login_client/CHANGELOG.md
+++ b/packages/login_client/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.0.1
+
+- Downgrade `meta` dependency from `1.4.0` to `1.3.0`.
+
 # 2.0.0
 
 - **Breaking:** Migrate to null-safety.

--- a/packages/login_client/pubspec.yaml
+++ b/packages/login_client/pubspec.yaml
@@ -13,7 +13,7 @@ environment:
 dependencies:
   http: ^0.13.0
   http_parser: ^4.0.0
-  meta: ^1.4.0
+  meta: ^1.3.0
   oauth2: ^2.0.0
 
 dev_dependencies:

--- a/packages/login_client/pubspec.yaml
+++ b/packages/login_client/pubspec.yaml
@@ -1,5 +1,5 @@
 name: login_client
-version: 2.0.0
+version: 2.0.1
 homepage: https://github.com/leancodepl/flutter_corelibrary/tree/master/packages/login_client
 repository: https://github.com/leancodepl/flutter_corelibrary
 description: >-


### PR DESCRIPTION
> Because login_client >=2.0.0 depends on meta ^1.4.0 and every version of flutter from sdk depends on meta 1.3.0, login_client >=2.0.0 is incompatible with flutter from sdk.
