### PR TITLE
Introduce override_api_endpoint package

### DIFF
--- a/.github/workflows/override_api_endpoint-publish.yml
+++ b/.github/workflows/override_api_endpoint-publish.yml
@@ -1,0 +1,34 @@
+name: override_api_endpoint publish
+
+on:
+  push:
+    tags: ['override_api_endpoint-v*']
+
+jobs:
+  publish:
+    name: Publish to pub.dev
+
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: packages/override_api_endpoint
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup Dart
+        uses: dart-lang/setup-dart@v1
+        with:
+          sdk: 2.12.0
+
+      - name: Download pub.dev credentials
+        env:
+          CREDENTIALS: ${{ secrets.PUB_DEV_CREDENTIALS }}
+        run: |
+          mkdir -p ~/.pub-cache
+          echo $CREDENTIALS > ~/.pub-cache/credentials.json
+
+      - name: Publish
+        run: dart pub publish -f

--- a/.github/workflows/override_api_endpoint-test.yml
+++ b/.github/workflows/override_api_endpoint-test.yml
@@ -1,0 +1,61 @@
+name: override_api_endpoint test
+
+on:
+  push:
+    branches: [master]
+    ignore-tags: ['override_api_endpoint-v*']
+    paths:
+      - 'packages/override_api_endpoint/**'
+  pull_request:
+    branches: [master]
+    paths:
+      - 'packages/override_api_endpoint/**'
+
+jobs:
+  test:
+    name: Flutter ${{ matrix.channel }}${{ matrix.version }}
+
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+            - version: '2.0.6'
+            - version: '2.2.1'
+            - channel: stable
+            - channel: beta
+            - channel: dev
+
+    defaults:
+      run:
+        working-directory: packages/override_api_endpoint
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v1
+        with:
+          channel: ${{ matrix.channel }}
+          flutter-version: ${{ matrix.version }}
+
+      - name: Flutter version
+        run: flutter --version
+
+      - name: Cache pub dependencies
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.FLUTTER_HOME }}/.pub-cache
+          key: ${{ runner.os }}-pub-${{ hashFiles('**/pubspec.lock') }}
+          restore-keys: ${{ runner.os }}-pub-
+
+      - name: Download pub dependencies
+        run: flutter pub get
+
+      - name: Run analyzer
+        run: flutter analyze
+
+      - name: Dry run pub publish
+        # We don't want it to fail the CI, it's just to see how would `pub publish` behave.
+        run: dart pub publish --dry-run || true

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
-| Package | Documentation | pub | CI | 
+| Package | Documentation | pub | CI |
 | - | - | - | - |
 | [`cqrs`][cqrs-link] | [Documentation][cqrs-documentation] | [![cqrs pub.dev badge][cqrs-pub-badge]][cqrs-pub-badge-link] | [![][cqrs-build-badge]][cqrs-build-badge-link] |
 | [`login_client`][login_client-link] | [Documentation][login_client-documentation] | [![login_client pub.dev badge][login_client-pub-badge]][login_client-pub-badge-link] | [![][login_client-build-badge]][login_client-build-badge-link] |
 | [`login_client_flutter`][login_client_flutter-link] | [Documentation][login_client_flutter-documentation] | [![login_client_flutter pub.dev badge][login_client_flutter-pub-badge]][login_client_flutter-pub-badge-link] | [![][login_client_flutter-build-badge]][login_client_flutter-build-badge-link] |
+| [`override_api_endpoint`][override_api_endpoint-link] | [Documentation][override_api_endpoint-documentation] | [![override_api_endpoint pub.dev badge][override_api_endpoint-pub-badge]][override_api_endpoint-pub-badge-link] | [![][override_api_endpoint-build-badge]][override_api_endpoint-build-badge-link] |
 
 ## pub.dev release process
 
@@ -26,3 +27,9 @@ Tag your desired commit with `<package_name>-v<version>` and let the GitHub Acti
 [login_client_flutter-pub-badge-link]: https://pub.dev/packages/login_client_flutter
 [login_client_flutter-build-badge]: https://img.shields.io/github/workflow/status/leancodepl/flutter_corelibrary/login_client_flutter%20test
 [login_client_flutter-build-badge-link]: https://github.com/leancodepl/flutter_corelibrary/actions?query=workflow%3A%22login_client_flutter+test%22
+[override_api_endpoint-link]: https://github.com/leancodepl/flutter_corelibrary/tree/master/packages/override_api_endpoint
+[override_api_endpoint-documentation]: https://pub.dev/documentation/override_api_endpoint/latest/
+[override_api_endpoint-pub-badge]: https://img.shields.io/pub/v/override_api_endpoint
+[override_api_endpoint-pub-badge-link]: https://pub.dev/packages/override_api_endpoint
+[override_api_endpoint-build-badge]: https://img.shields.io/github/workflow/status/leancodepl/flutter_corelibrary/override_api_endpoint%20test
+[override_api_endpoint-build-badge-link]: https://github.com/leancodepl/flutter_corelibrary/actions?query=workflow%3A%22override_api_endpoint+test%22

--- a/packages/override_api_endpoint/.gitignore
+++ b/packages/override_api_endpoint/.gitignore
@@ -1,0 +1,121 @@
+# Miscellaneous
+*.class
+*.lock
+*.log
+*.pyc
+*.swp
+.DS_Store
+.atom/
+.buildlog/
+.history
+.svn/
+
+# IntelliJ related
+*.iml
+*.ipr
+*.iws
+.idea/
+
+# Visual Studio Code related
+.classpath
+.project
+.settings/
+.vscode/
+
+# Flutter repo-specific
+/bin/cache/
+/bin/internal/bootstrap.bat
+/bin/internal/bootstrap.sh
+/bin/mingit/
+/dev/benchmarks/mega_gallery/
+/dev/bots/.recipe_deps
+/dev/bots/android_tools/
+/dev/devicelab/ABresults*.json
+/dev/docs/doc/
+/dev/docs/flutter.docs.zip
+/dev/docs/lib/
+/dev/docs/pubspec.yaml
+/dev/integration_tests/**/xcuserdata
+/dev/integration_tests/**/Pods
+/packages/flutter/coverage/
+version
+analysis_benchmark.json
+
+# packages file containing multi-root paths
+.packages.generated
+
+# Flutter/Dart/Pub related
+**/doc/api/
+.dart_tool/
+.flutter-plugins
+.flutter-plugins-dependencies
+**/generated_plugin_registrant.dart
+.packages
+.pub-cache/
+.pub/
+build/
+flutter_*.png
+linked_*.ds
+unlinked.ds
+unlinked_spec.ds
+
+# Android related
+**/android/**/gradle-wrapper.jar
+**/android/.gradle
+**/android/captures/
+**/android/gradlew
+**/android/gradlew.bat
+**/android/local.properties
+**/android/**/GeneratedPluginRegistrant.java
+**/android/key.properties
+*.jks
+
+# iOS/XCode related
+**/ios/**/*.mode1v3
+**/ios/**/*.mode2v3
+**/ios/**/*.moved-aside
+**/ios/**/*.pbxuser
+**/ios/**/*.perspectivev3
+**/ios/**/*sync/
+**/ios/**/.sconsign.dblite
+**/ios/**/.tags*
+**/ios/**/.vagrant/
+**/ios/**/DerivedData/
+**/ios/**/Icon?
+**/ios/**/Pods/
+**/ios/**/.symlinks/
+**/ios/**/profile
+**/ios/**/xcuserdata
+**/ios/.generated/
+**/ios/Flutter/.last_build_id
+**/ios/Flutter/App.framework
+**/ios/Flutter/Flutter.framework
+**/ios/Flutter/Flutter.podspec
+**/ios/Flutter/Generated.xcconfig
+**/ios/Flutter/app.flx
+**/ios/Flutter/app.zip
+**/ios/Flutter/flutter_assets/
+**/ios/Flutter/flutter_export_environment.sh
+**/ios/ServiceDefinitions.json
+**/ios/Runner/GeneratedPluginRegistrant.*
+
+# macOS
+**/macos/Flutter/GeneratedPluginRegistrant.swift
+**/macos/Flutter/Flutter-Debug.xcconfig
+**/macos/Flutter/Flutter-Release.xcconfig
+**/macos/Flutter/Flutter-Profile.xcconfig
+
+# Coverage
+coverage/
+test/.test_coverage.dart
+
+# Symbols
+app.*.symbols
+
+# Exceptions to above rules.
+!**/ios/**/default.mode1v3
+!**/ios/**/default.mode2v3
+!**/ios/**/default.pbxuser
+!**/ios/**/default.perspectivev3
+!/packages/flutter_tools/test/data/dart_dependencies_test/**/.packages
+!/dev/ci/**/Gemfile.lock

--- a/packages/override_api_endpoint/.metadata
+++ b/packages/override_api_endpoint/.metadata
@@ -1,0 +1,10 @@
+# This file tracks properties of this Flutter project.
+# Used by Flutter tool to assess capabilities and perform upgrades etc.
+#
+# This file should be version controlled and should not be manually edited.
+
+version:
+  revision: 8661d8aecd626f7f57ccbcb735553edc05a2e713
+  channel: stable
+
+project_type: package

--- a/packages/override_api_endpoint/CHANGELOG.md
+++ b/packages/override_api_endpoint/CHANGELOG.md
@@ -1,0 +1,3 @@
+# 1.0.0
+
+- Initial release

--- a/packages/override_api_endpoint/LICENSE
+++ b/packages/override_api_endpoint/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2021 LeanCode Sp. z o.o.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/override_api_endpoint/README.md
+++ b/packages/override_api_endpoint/README.md
@@ -1,0 +1,25 @@
+# override_api_endpoint
+
+[![override_api_endpoint pub.dev badge][pub-badge]][pub-badge-link]
+[![][build-badge]][build-badge-link]
+[![][codecov-badge]][codecov-badge-link]
+
+Overrides and persists default api endpoint for test environment.
+
+## Usage
+
+```dart
+final apiEndpoint = await overrideApiEndpoint(
+  'override',
+  'apiAddress',
+  Uri.parse('https://api.example.com/'),
+);
+```
+[pub-badge]: https://img.shields.io/pub/v/override_api_endpoint
+[pub-badge-link]: https://pub.dev/packages/override_api_endpoint
+[build-badge]: https://img.shields.io/github/workflow/status/leancodepl/flutter_corelibrary/override_api_endpoint%20test
+[build-badge-link]: https://github.com/leancodepl/flutter_corelibrary/actions?query=workflow%3A%22override_api_endpoint+test%22
+[codecov-badge]: https://img.shields.io/codecov/c/gh/leancodepl/flutter_corelibrary?flag=override_api_endpoint
+[codecov-badge-link]: https://codecov.io/gh/leancodepl/flutter_corelibrary
+[snippet]: assets/snippet.png
+[override_api_endpoint_flutter]: https://pub.dev/packages/override_api_endpoint_flutter

--- a/packages/override_api_endpoint/README.md
+++ b/packages/override_api_endpoint/README.md
@@ -7,7 +7,7 @@
 Overrides and persists default API endpoint for the test environment.
 
 The `deeplinkOverrideSegment` is the part of deeplink that uniquely
-identifies deepling that is used to override API endpoint
+identifies deeplink that is used to override API endpoint
 eg. `override` in `app://app/override?apiAddress=https%3A%2F%2Fexample.com`
 
 The `deeplinkQueryParameter` is the query parameter of the override API

--- a/packages/override_api_endpoint/README.md
+++ b/packages/override_api_endpoint/README.md
@@ -4,7 +4,7 @@
 [![][build-badge]][build-badge-link]
 [![][codecov-badge]][codecov-badge-link]
 
-Overrides and persists default api endpoint for test environment.
+Overrides and persists default API endpoint for the test environment.
 
 ## Usage
 
@@ -21,5 +21,4 @@ final apiEndpoint = await overrideApiEndpoint(
 [build-badge-link]: https://github.com/leancodepl/flutter_corelibrary/actions?query=workflow%3A%22override_api_endpoint+test%22
 [codecov-badge]: https://img.shields.io/codecov/c/gh/leancodepl/flutter_corelibrary?flag=override_api_endpoint
 [codecov-badge-link]: https://codecov.io/gh/leancodepl/flutter_corelibrary
-[snippet]: assets/snippet.png
 [override_api_endpoint_flutter]: https://pub.dev/packages/override_api_endpoint_flutter

--- a/packages/override_api_endpoint/README.md
+++ b/packages/override_api_endpoint/README.md
@@ -6,6 +6,18 @@
 
 Overrides and persists default API endpoint for the test environment.
 
+The `deeplinkOverrideSegment` is the part of deeplink that uniquely
+identifies deepling that is used to override API endpoint
+eg. `override` in `app://app/override?apiAddress=https%3A%2F%2Fexample.com`
+
+The `deeplinkQueryParameter` is the query parameter of the override API
+endpoint deeplink that contains url encoded API endpoint to be used
+eg. `apiAddress` in `app://app/override?apiAddress=https%3A%2F%2Fexample.com`
+
+The `defaultEndpoint` is fallback url that should be used if app does not
+have any endpoint introduced via deeplink or if `deeplinkQueryParameter` is
+not provided
+
 ## Usage
 
 ```dart

--- a/packages/override_api_endpoint/analysis_options.yaml
+++ b/packages/override_api_endpoint/analysis_options.yaml
@@ -1,0 +1,9 @@
+include: package:lint/analysis_options_package.yaml
+
+analyzer:
+  exclude:
+    - test/.test_coverage.dart
+
+linter:
+  rules:
+    - sort_constructors_first

--- a/packages/override_api_endpoint/analysis_options.yaml
+++ b/packages/override_api_endpoint/analysis_options.yaml
@@ -1,9 +1,5 @@
 include: package:lint/analysis_options_package.yaml
 
-analyzer:
-  exclude:
-    - test/.test_coverage.dart
-
 linter:
   rules:
     - sort_constructors_first

--- a/packages/override_api_endpoint/lib/override_api_endpoint.dart
+++ b/packages/override_api_endpoint/lib/override_api_endpoint.dart
@@ -1,0 +1,3 @@
+library override_api_endpoint;
+
+export 'src/override_api_endpoint.dart';

--- a/packages/override_api_endpoint/lib/src/override_api_endpoint.dart
+++ b/packages/override_api_endpoint/lib/src/override_api_endpoint.dart
@@ -15,31 +15,31 @@ typedef GetUri = Future<Uri?> Function();
 /// The `defaultEndpoint` is fallback url that should be used if app does not
 /// have any endpoint introduced via deeplink or if `deeplinkQueryParameter` is
 /// not provided
-Future<Uri> overrideApiEndpoint(
-  SharedPreferences _sharedPreferences,
-  GetUri _getInitialUri,
-  String deeplinkOverrideSegment,
-  String deeplinkQueryParameter,
-  Uri defaultEndpoint, {
+Future<Uri> overrideApiEndpoint({
+  required SharedPreferences sharedPreferences,
+  required GetUri getInitialUri,
+  required String deeplinkOverrideSegment,
+  required String deeplinkQueryParameter,
+  required Uri defaultEndpoint,
   String apiEndpointKey = 'apiAddress',
 }) async {
   var apiEndpoint = defaultEndpoint;
 
-  if (_sharedPreferences.containsKey(apiEndpointKey)) {
-    apiEndpoint = Uri.parse(_sharedPreferences.getString(apiEndpointKey)!);
+  if (sharedPreferences.containsKey(apiEndpointKey)) {
+    apiEndpoint = Uri.parse(sharedPreferences.getString(apiEndpointKey)!);
   }
 
-  final initial = await _getInitialUri();
+  final initial = await getInitialUri();
 
   if (initial != null && initial.path.contains(deeplinkOverrideSegment)) {
     final endpointFromDeeplink =
         initial.queryParameters[deeplinkQueryParameter];
     if (endpointFromDeeplink?.isEmpty ?? true) {
-      _sharedPreferences.remove(apiEndpointKey);
+      sharedPreferences.remove(apiEndpointKey);
       apiEndpoint = defaultEndpoint;
     } else {
       apiEndpoint = Uri.parse(endpointFromDeeplink!);
-      _sharedPreferences.setString(apiEndpointKey, apiEndpoint.toString());
+      sharedPreferences.setString(apiEndpointKey, apiEndpoint.toString());
     }
   }
 

--- a/packages/override_api_endpoint/lib/src/override_api_endpoint.dart
+++ b/packages/override_api_endpoint/lib/src/override_api_endpoint.dart
@@ -1,6 +1,6 @@
-import 'package:shared_preferences/shared_preferences.dart';
+import 'dart:async';
 
-typedef GetUri = Future<Uri?> Function();
+import 'package:shared_preferences/shared_preferences.dart';
 
 /// Overrides and persists API endpoint for the test environment
 ///
@@ -17,7 +17,7 @@ typedef GetUri = Future<Uri?> Function();
 /// not provided
 Future<Uri> overrideApiEndpoint({
   required SharedPreferences sharedPreferences,
-  required GetUri getInitialUri,
+  required FutureOr<Uri?> Function() getInitialUri,
   required String deeplinkOverrideSegment,
   required String deeplinkQueryParameter,
   required Uri defaultEndpoint,

--- a/packages/override_api_endpoint/lib/src/override_api_endpoint.dart
+++ b/packages/override_api_endpoint/lib/src/override_api_endpoint.dart
@@ -1,0 +1,34 @@
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:uni_links/uni_links.dart';
+
+Future<Uri> overrideApiEndpoint(
+  String deeplinkOverrideSegment,
+  String deeplinkQueryParameter,
+  Uri defaultEndpoint,
+) async {
+  const apiEndpointKey = 'apiAddress';
+
+  final sharedPreferences = await SharedPreferences.getInstance();
+
+  var apiEndpoint = defaultEndpoint;
+
+  if (sharedPreferences.containsKey(apiEndpointKey)) {
+    apiEndpoint = Uri.parse(sharedPreferences.getString(apiEndpointKey)!);
+  }
+
+  final initial = await getInitialUri();
+
+  if (initial != null && initial.path.contains(deeplinkOverrideSegment)) {
+    final endpointFromDeeplink =
+        initial.queryParameters[deeplinkQueryParameter];
+    if (endpointFromDeeplink?.isEmpty ?? true) {
+      sharedPreferences.remove(apiEndpointKey);
+      apiEndpoint = defaultEndpoint;
+    } else {
+      apiEndpoint = Uri.parse(endpointFromDeeplink!);
+      sharedPreferences.setString(apiEndpointKey, apiEndpoint.toString());
+    }
+  }
+
+  return apiEndpoint;
+}

--- a/packages/override_api_endpoint/lib/src/override_api_endpoint.dart
+++ b/packages/override_api_endpoint/lib/src/override_api_endpoint.dart
@@ -5,7 +5,7 @@ typedef GetUri = Future<Uri?> Function();
 /// Overrides and persists API endpoint for the test environment
 ///
 /// The `deeplinkOverrideSegment` is the part of deeplink that uniquely
-/// identifies deepling that is used to override API endpoint
+/// identifies deeplink that is used to override API endpoint
 /// eg. `override` in `app://app/override?apiAddress=https%3A%2F%2Fexample.com`
 ///
 /// The `deeplinkQueryParameter` is the query parameter of the override API

--- a/packages/override_api_endpoint/lib/src/override_api_endpoint.dart
+++ b/packages/override_api_endpoint/lib/src/override_api_endpoint.dart
@@ -1,6 +1,19 @@
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:uni_links/uni_links.dart';
 
+/// Overrides and persists API endpoint for the test environment
+///
+/// The `deeplinkOverrideSegment` is the part of deeplink that uniquely
+/// identifies deepling that is used to override API endpoint
+/// eg. `override` in `app://app/override?apiAddress=https%3A%2F%2Fexample.com`
+///
+/// The `deeplinkQueryParameter` is the query parameter of the override API
+/// endpoint deeplink that contains url encoded API endpoint to be used
+/// eg. `apiAddress` in `app://app/override?apiAddress=https%3A%2F%2Fexample.com`
+///
+/// The `defaultEndpoint` is fallback url that should be used if app does not
+/// have any endpoint introduced via deeplink or if `deeplinkQueryParameter` is
+/// not provided
 Future<Uri> overrideApiEndpoint(
   String deeplinkOverrideSegment,
   String deeplinkQueryParameter,

--- a/packages/override_api_endpoint/pubspec.yaml
+++ b/packages/override_api_endpoint/pubspec.yaml
@@ -9,12 +9,11 @@ description: >-
   is used.
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
-  flutter: '>=2.0.0'
+  sdk: ">=2.12.0 <3.0.0"
+  flutter: ">=2.0.0"
 
 dependencies:
   shared_preferences: ^2.0.6
-  uni_links: ^0.5.1
 
 dev_dependencies:
   lint: ^1.5.3

--- a/packages/override_api_endpoint/pubspec.yaml
+++ b/packages/override_api_endpoint/pubspec.yaml
@@ -4,8 +4,8 @@ homepage: https://github.com/leancodepl/flutter_corelibrary/tree/master/packages
 repository: https://github.com/leancodepl/flutter_corelibrary
 description: >-
   This package is prepared so that backend developers can override api endpoint
-  fo some local one without the need to compiling the app. Desired behavior is
-  realized with deeplinks. The override url is persisted until new deeplink
+  for some local one without the need to compile the app. The desired behavior is
+  realized with deeplinks. The override URL is persisted until a new deeplink
   is used.
 
 environment:

--- a/packages/override_api_endpoint/pubspec.yaml
+++ b/packages/override_api_endpoint/pubspec.yaml
@@ -1,0 +1,24 @@
+name: override_api_endpoint
+version: 1.0.0
+homepage: https://github.com/leancodepl/flutter_corelibrary/tree/master/packages/override_api_endpoint
+repository: https://github.com/leancodepl/flutter_corelibrary
+description: >-
+  This package is prepared so that backend developers can override api endpoint
+  fo some local one without the need to compiling the app. Desired behavior is
+  realized with deeplinks. The override url is persisted until new deeplink
+  is used.
+
+environment:
+  sdk: '>=2.12.0 <3.0.0'
+  flutter: '>=2.0.0'
+
+dependencies:
+  shared_preferences: ^2.0.6
+  uni_links: ^0.5.1
+
+dev_dependencies:
+  build_runner: ^1.11.5
+  coverage: ^1.0.3
+  lint: ^1.5.3
+  mockito: ^5.0.0
+  test: ^1.16.4

--- a/packages/override_api_endpoint/pubspec.yaml
+++ b/packages/override_api_endpoint/pubspec.yaml
@@ -17,8 +17,4 @@ dependencies:
   uni_links: ^0.5.1
 
 dev_dependencies:
-  build_runner: ^1.11.5
-  coverage: ^1.0.3
   lint: ^1.5.3
-  mockito: ^5.0.0
-  test: ^1.16.4


### PR DESCRIPTION
So this is basically the feature requested by @jakubfijalkowski that will allow backend devs to use test builds with local (dev) backend. To override endpoint you need to launch app with correctly set up deeplink. The endpoint is persisted using `SharedPreferences`.