### PR TITLE
[login_client] Fix closing default HTTP client after logging out.

### DIFF
--- a/packages/login_client/CHANGELOG.md
+++ b/packages/login_client/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.0.2
+
+- Fix closing default HTTP client after logging out.
+
 # 2.0.1
 
 - Downgrade `meta` dependency from `1.4.0` to `1.3.0`.

--- a/packages/login_client/lib/src/login_client.dart
+++ b/packages/login_client/lib/src/login_client.dart
@@ -108,7 +108,6 @@ class LoginClient extends http.BaseClient {
   /// This method will log the [LoginClient] out on the authorization failure.
   Future<void> logIn(AuthorizationStrategy strategy) async {
     try {
-      _oAuthClient?.close();
       _oAuthClient = await strategy.execute(
         _oAuthSettings,
         _httpClient,

--- a/packages/login_client/pubspec.yaml
+++ b/packages/login_client/pubspec.yaml
@@ -1,5 +1,5 @@
 name: login_client
-version: 2.0.1
+version: 2.0.2
 homepage: https://github.com/leancodepl/flutter_corelibrary/tree/master/packages/login_client
 repository: https://github.com/leancodepl/flutter_corelibrary
 description: >-


### PR DESCRIPTION
Fix closing the OAuthClient, that the only thing it does is closing the inner HTTP client (that is the same as the one we use for unauthorized users). https://github.com/dart-lang/oauth2/blob/master/lib/src/client.dart#L184

CC @FlowerAlex