### PR TITLE
Feature/command result to json

### DIFF
--- a/packages/cqrs/CHANGELOG.md
+++ b/packages/cqrs/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 6.1.0
+
+- `CommandResult` and `ValidationError` now implement the `toJson()` method
+
 # 6.0.0
 
 - Stable null-safe release.

--- a/packages/cqrs/lib/src/command_result.dart
+++ b/packages/cqrs/lib/src/command_result.dart
@@ -47,6 +47,11 @@ class CommandResult {
   /// its validation errors related to the `propertyName`.
   bool hasErrorForProperty(int code, String propertyName) => errors
       .any((error) => error.code == code && error.propertyName == propertyName);
+
+  Map<String, dynamic> toJson() => {
+        'WasSuccessful': success,
+        'ValidationErrors': errors.map((error) => error.toJson()).toList(),
+      };
 }
 
 /// A validation error.
@@ -66,6 +71,12 @@ class ValidationError {
 
   /// Path to the property which caused the error.
   final String propertyName;
+
+  Map<String, dynamic> toJson() => {
+        'ErrorCode': code,
+        'ErrorMessage': message,
+        'PropertyName': propertyName
+      };
 
   @override
   String toString() => '[$propertyName] $code: $message';

--- a/packages/cqrs/pubspec.yaml
+++ b/packages/cqrs/pubspec.yaml
@@ -1,5 +1,5 @@
 name: cqrs
-version: 6.0.0
+version: 6.1.0
 homepage: https://github.com/leancodepl/flutter_corelibrary/tree/master/packages/cqrs
 repository: https://github.com/leancodepl/flutter_corelibrary
 description: >-

--- a/packages/cqrs/test/command_result_test.dart
+++ b/packages/cqrs/test/command_result_test.dart
@@ -126,5 +126,42 @@ void main() {
         );
       });
     });
+
+    group('is correctly serialized to JSON', () {
+      test('with some validation errors', () {
+        final json = CommandResult.fromJson({
+          'WasSuccessful': false,
+          'ValidationErrors': [
+            {
+              'ErrorCode': 12,
+              'ErrorMessage': 'This is an error.',
+              'PropertyName': 'Property',
+            },
+          ],
+        }).toJson();
+
+        expect(json['WasSuccessful'], false);
+        expect(
+          json['ValidationErrors'],
+          contains(
+            isA<Map<String, dynamic>>()
+                .having((e) => e['ErrorCode'], 'code', 12)
+                .having(
+                    (e) => e['ErrorMessage'], 'message', 'This is an error.')
+                .having((e) => e['PropertyName'], 'propertyNamme', 'Property'),
+          ),
+        );
+      });
+
+      test('without validation errors, with success', () {
+        final json = CommandResult.fromJson({
+          'WasSuccessful': true,
+          'ValidationErrors': [],
+        }).toJson();
+
+        expect(json['WasSuccessful'], true);
+        expect(json['ValidationErrors'], isEmpty);
+      });
+    });
   });
 }

--- a/packages/cqrs/test/validation_error_test.dart
+++ b/packages/cqrs/test/validation_error_test.dart
@@ -28,5 +28,17 @@ void main() {
       expect(error.message, 'Some other message');
       expect(error.propertyName, 'Property');
     });
+
+    test('is correctly serialized to JSON', () {
+      final json = ValidationError.fromJson({
+        'ErrorCode': 128,
+        'ErrorMessage': 'Some other message',
+        'PropertyName': 'Property',
+      }).toJson();
+
+      expect(json['ErrorCode'], 128);
+      expect(json['ErrorMessage'], 'Some other message');
+      expect(json['PropertyName'], 'Property');
+    });
   });
 }


### PR DESCRIPTION
New contracts now use the `CommandResult` type, which means it has to be serializable. This PR adds `toJson` methods where needed to enable serialization on the `CommandResult` type.