### PR TITLE
Increase flutter_secure_storage version range

### DIFF
--- a/packages/login_client_flutter/CHANGELOG.md
+++ b/packages/login_client_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.0.1
+
+- Increase `flutter_secure_storage` version range to `>=4.2.0 <6.0.0`.
+
 # 2.0.0
 
 - **Breaking:** Migrate to null-safety.

--- a/packages/login_client_flutter/pubspec.yaml
+++ b/packages/login_client_flutter/pubspec.yaml
@@ -1,5 +1,5 @@
 name: login_client_flutter
-version: 2.0.0
+version: 2.0.1
 homepage: https://github.com/leancodepl/flutter_corelibrary/tree/master/packages/login_client_flutter
 repository: https://github.com/leancodepl/flutter_corelibrary
 description: >-
@@ -13,7 +13,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_secure_storage: ^4.2.0
+  flutter_secure_storage: '>=4.2.0 <6.0.0'
   login_client: ^2.0.1
 
 dev_dependencies:


### PR DESCRIPTION
Actually closes #31 

As far as I can tell the API has not changed, tested 4.2.0 and 5.0.0 and both seem to work.