### PR TITLE
Disable 2 lints that we don't want

### DIFF
--- a/packages/leancode_lint/CHANGELOG.md
+++ b/packages/leancode_lint/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.2.1
+
+- Disable the following lints:
+  - [use_build_context_synchronously](https://dart-lang.github.io/linter/lints/use_build_context_synchronously)
+  - [library_private_types_in_public_api](https://dart-lang.github.io/linter/lints/library_private_types_in_public_api)
+
 # 1.2.0
 
 - Enable the following lints:

--- a/packages/leancode_lint/README.md
+++ b/packages/leancode_lint/README.md
@@ -10,7 +10,7 @@ Add `leancode_lint` as a dev dependency.
 
 ```yaml
 dev_dependencies:
-  leancode_lint: ^1.3.1
+  leancode_lint: ^1.2.1
 ```
 
 ## Usage

--- a/packages/leancode_lint/README.md
+++ b/packages/leancode_lint/README.md
@@ -10,19 +10,7 @@ Add `leancode_lint` as a dev dependency.
 
 ```yaml
 dev_dependencies:
-  leancode_lint: ^1.0.2
-```
-
-### Dart <2.14
-
-When using Dart <2.14, consider adding `leancode_lint` as a normal dependency
-instead to access the
-[`unawaited`](https://api.dart.dev/stable/2.14.0/dart-async/unawaited.html)
-function.
-
-```yaml
-dependencies:
-  leancode_lint: ^1.0.2
+  leancode_lint: ^1.3.1
 ```
 
 ## Usage

--- a/packages/leancode_lint/lib/analysis_options.yaml
+++ b/packages/leancode_lint/lib/analysis_options.yaml
@@ -189,7 +189,7 @@ linter:
     # Included in lints recommended
     # - library_prefixes
 
-    # - library_private_types_in_public_api
+    - library_private_types_in_public_api: false
 
     # - lines_longer_than_80_chars
 
@@ -428,7 +428,7 @@ linter:
 
     - unsafe_html
 
-    # - use_build_context_synchronously
+    - use_build_context_synchronously: false
 
     # Included in flutter_lints
     # - use_full_hex_values_for_flutter_colors

--- a/packages/leancode_lint/pubspec.yaml
+++ b/packages/leancode_lint/pubspec.yaml
@@ -1,5 +1,5 @@
 name: leancode_lint
-version: 1.2.0
+version: 1.2.1
 homepage: https://github.com/leancodepl/flutter_corelibrary/tree/master/packages/leancode_lint
 repository: https://github.com/leancodepl/flutter_corelibrary
 description: Lint rules used at LeanCode.


### PR DESCRIPTION
- disable unwanted lints
- update version

Also removed part of docs talking about Dart <2.14, which we don't support.