### PR TITLE
Remove the `unawaited()` function

### DIFF
--- a/packages/leancode_lint/CHANGELOG.md
+++ b/packages/leancode_lint/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- Remove the `unawaited()` function which is provided by Dart since 2.14 (#88)
+
 # 1.3.0
 
 - Enable the following lints:

--- a/packages/leancode_lint/lib/leancode_lint.dart
+++ b/packages/leancode_lint/lib/leancode_lint.dart
@@ -1,1 +1,0 @@
-export 'src/unawaited.dart';

--- a/packages/leancode_lint/lib/src/unawaited.dart
+++ b/packages/leancode_lint/lib/src/unawaited.dart
@@ -1,2 +1,0 @@
-/// Explicitly ignore a future.
-void unawaited(Future<void>? future) {}


### PR DESCRIPTION
Minimum Dart SDK version of `leancode_lint` is `2.17.0`, and `unawaited()` has been in Dart's stdlib since Dart 2.14.

See also:
- [unawaited function API reference](https://api.dart.dev/stable/dart-async/unawaited.html)