### PR TITLE
leancode_lint: bump version

### DIFF
--- a/packages/leancode_lint/CHANGELOG.md
+++ b/packages/leancode_lint/CHANGELOG.md
@@ -1,7 +1,8 @@
-## Unreleased
+## 2.0.0
 
+- **Breaking:** Remove the `unawaited()` function which is provided by Dart
+  since 2.14 (#88)
 - Disable the `discarded_futures` lint (#87)
-- Remove the `unawaited()` function which is provided by Dart since 2.14 (#88)
 - Disable the deprecated `invariant_booleans` lint (#86)
 
 # 1.3.0

--- a/packages/leancode_lint/pubspec.yaml
+++ b/packages/leancode_lint/pubspec.yaml
@@ -1,5 +1,5 @@
 name: leancode_lint
-version: 1.3.0
+version: 2.0.0
 homepage: https://github.com/leancodepl/flutter_corelibrary/tree/master/packages/leancode_lint
 repository: https://github.com/leancodepl/flutter_corelibrary
 description: Lint rules used at LeanCode.


### PR DESCRIPTION
Not sure what version to choose.

This can be potentially breaking if someone was depending on `unawaited()` from `package:leancode_lint`. They'll have to use `unawaited()` from `dart:async` instead.