### PR TITLE
Fix README build badges

### DIFF
--- a/.github/workflows/leancode_hooks-test.yml
+++ b/.github/workflows/leancode_hooks-test.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - channel: stable
+          - version: 3.0.5
 
     defaults:
       run:

--- a/.github/workflows/login_client_flutter-test.yml
+++ b/.github/workflows/login_client_flutter-test.yml
@@ -21,8 +21,7 @@ jobs:
       matrix:
         include:
           - version: '2.5.0'
-          - channel: stable
-          - channel: beta
+          - version: '3.3'
 
     defaults:
       run:

--- a/.github/workflows/override_api_endpoint-test.yml
+++ b/.github/workflows/override_api_endpoint-test.yml
@@ -21,8 +21,7 @@ jobs:
       matrix:
         include:
           - version: '2.5.0'
-          - channel: stable
-          - channel: beta
+          - version: '3.3'
 
     defaults:
       run:

--- a/README.md
+++ b/README.md
@@ -45,5 +45,5 @@ Tag your desired commit with `<package_name>-v<version>` and let the GitHub Acti
 [override_api_endpoint-documentation]: https://pub.dev/documentation/override_api_endpoint/latest/
 [override_api_endpoint-pub-badge]: https://img.shields.io/pub/v/override_api_endpoint
 [override_api_endpoint-pub-badge-link]: https://pub.dev/packages/override_api_endpoint
-[override_api_endpoint-build-badge]: https://img.shields.io/github/workflow/status/leancodepl/flutter_corelibrary/override_api_endpoint%20test
-[override_api_endpoint-build-badge-link]: https://github.com/leancodepl/flutter_corelibrary/actions?query=workflow%3A%22override_api_endpoint+test%22
+[override_api_endpoint-build-badge]: https://img.shields.io/github/actions/workflow/status/leancodepl/flutter_corelibrary/override_api_endpoint-test.yml?branch=master
+[override_api_endpoint-build-badge-link]: https://github.com/leancodepl/flutter_corelibrary/actions/workflows/override_api_endpoint-test.yml

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ Tag your desired commit with `<package_name>-v<version>` and let the GitHub Acti
 [login_client-documentation]: https://pub.dev/documentation/login_client/latest/
 [login_client-pub-badge]: https://img.shields.io/pub/v/login_client
 [login_client-pub-badge-link]: https://pub.dev/packages/login_client
-[login_client-build-badge]: https://img.shields.io/github/workflow/status/leancodepl/flutter_corelibrary/login_client%20test
-[login_client-build-badge-link]: https://github.com/leancodepl/flutter_corelibrary/actions?query=workflow%3A%22login_client+test%22
+[login_client-build-badge]: https://img.shields.io/github/actions/workflow/status/leancodepl/flutter_corelibrary/login_client-test.yml?branch=master
+[login_client-build-badge-link]: https://github.com/leancodepl/flutter_corelibrary/actions/workflows/login_client-test.yml
 [login_client_flutter-link]: https://github.com/leancodepl/flutter_corelibrary/tree/master/packages/login_client_flutter
 [login_client_flutter-documentation]: https://pub.dev/documentation/login_client_flutter/latest/
 [login_client_flutter-pub-badge]: https://img.shields.io/pub/v/login_client_flutter

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ Tag your desired commit with `<package_name>-v<version>` and let the GitHub Acti
 [leancode_hooks-pub-badge]: https://img.shields.io/pub/v/leancode_hooks
 [leancode_hooks-pub-badge-link]: https://pub.dev/packages/leancode_hooks
 
-[leancode_hooks-build-badge]: https://img.shields.io/github/workflow/status/leancodepl/flutter_corelibrary/leancode_hooks%20test
-[leancode_hooks-build-badge-link]: https://github.com/leancodepl/flutter_corelibrary/actions?query=workflow%3A%22leancode_hooks+test%22
+[leancode_hooks-build-badge]: https://img.shields.io/github/actions/workflow/status/leancodepl/flutter_corelibrary/leancode_hooks-test.yml?branch=master
+[leancode_hooks-build-badge-link]: https://github.com/leancodepl/flutter_corelibrary/actions/workflows/leancode_hooks-test.yml
 
 [login_client-link]: https://github.com/leancodepl/flutter_corelibrary/tree/master/packages/login_client
 [login_client-documentation]: https://pub.dev/documentation/login_client/latest/

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Tag your desired commit with `<package_name>-v<version>` and let the GitHub Acti
 [cqrs-documentation]: https://pub.dev/documentation/cqrs/latest/
 [cqrs-pub-badge]: https://img.shields.io/pub/v/cqrs
 [cqrs-pub-badge-link]: https://pub.dev/packages/cqrs
-[cqrs-build-badge]: https://img.shields.io/github/workflow/status/leancodepl/flutter_corelibrary/cqrs%20test
-[cqrs-build-badge-link]: https://github.com/leancodepl/flutter_corelibrary/actions?query=workflow%3A%22cqrs+test%22
+[cqrs-build-badge]: https://img.shields.io/github/actions/workflow/status/leancodepl/flutter_corelibrary/cqrs-test.yml?branch=master
+[cqrs-build-badge-link]: https://github.com/leancodepl/flutter_corelibrary/actions/workflows/cqrs-test.yml
 [leancode_lint-link]: https://github.com/leancodepl/flutter_corelibrary/tree/master/packages/leancode_lint
 [leancode_lint-documentation]: https://pub.dev/documentation/leancode_lint/latest/
 [leancode_lint-pub-badge]: https://img.shields.io/pub/v/leancode_lint

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ Tag your desired commit with `<package_name>-v<version>` and let the GitHub Acti
 [login_client_flutter-documentation]: https://pub.dev/documentation/login_client_flutter/latest/
 [login_client_flutter-pub-badge]: https://img.shields.io/pub/v/login_client_flutter
 [login_client_flutter-pub-badge-link]: https://pub.dev/packages/login_client_flutter
-[login_client_flutter-build-badge]: https://img.shields.io/github/workflow/status/leancodepl/flutter_corelibrary/login_client_flutter%20test
-[login_client_flutter-build-badge-link]: https://github.com/leancodepl/flutter_corelibrary/actions?query=workflow%3A%22login_client_flutter+test%22
+[login_client_flutter-build-badge]: https://img.shields.io/github/actions/workflow/status/leancodepl/flutter_corelibrary/login_client_flutter-test.yml?branch=master
+[login_client_flutter-build-badge-link]: https://github.com/leancodepl/flutter_corelibrary/actions/workflows/login_client_flutter-test.yml
 [override_api_endpoint-link]: https://github.com/leancodepl/flutter_corelibrary/tree/master/packages/override_api_endpoint
 [override_api_endpoint-documentation]: https://pub.dev/documentation/override_api_endpoint/latest/
 [override_api_endpoint-pub-badge]: https://img.shields.io/pub/v/override_api_endpoint

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,14 +3,16 @@ coverage:
     project:
       default:
         target: auto
+        informational: true
       cqrs:
-        target: auto
         flags:
           - cqrs
       login_client:
-        target: auto
         flags:
           - login_client
+      leancode_hooks:
+        flags:
+          - leancode_hooks
 
 comment:
   branches: null
@@ -21,4 +23,7 @@ flags:
     carryforward: true
   login_client:
     paths: ['packages/login_client']
+    carryforward: true
+  leancode_hooks:
+    paths: ['packages/leancode_hooks']
     carryforward: true

--- a/packages/cqrs/CHANGELOG.md
+++ b/packages/cqrs/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 8.0.0+1
+
+- Fix build badge in README.
+
 # 8.0.0
 
 - **Breaking:** Bump minimum Dart version to 2.17.

--- a/packages/cqrs/README.md
+++ b/packages/cqrs/README.md
@@ -72,7 +72,7 @@ if (result.success) {
 
 [pub-badge]: https://img.shields.io/pub/v/cqrs
 [pub-badge-link]: https://pub.dev/packages/cqrs
-[build-badge]: https://img.shields.io/github/workflow/status/leancodepl/flutter_corelibrary/cqrs%20test
-[build-badge-link]: https://github.com/leancodepl/flutter_corelibrary/actions?query=workflow%3A%22cqrs+test%22
+[build-badge]: https://img.shields.io/github/actions/workflow/status/leancodepl/flutter_corelibrary/cqrs-test.yml?branch=master
+[build-badge-link]: https://github.com/leancodepl/flutter_corelibrary/actions/workflows/cqrs-test.yml
 [codecov-badge]: https://img.shields.io/codecov/c/gh/leancodepl/flutter_corelibrary?flag=cqrs
 [codecov-badge-link]: https://codecov.io/gh/leancodepl/flutter_corelibrary

--- a/packages/cqrs/pubspec.yaml
+++ b/packages/cqrs/pubspec.yaml
@@ -1,5 +1,5 @@
 name: cqrs
-version: 7.0.0
+version: 8.0.0+1
 homepage: https://github.com/leancodepl/flutter_corelibrary/tree/master/packages/cqrs
 repository: https://github.com/leancodepl/flutter_corelibrary
 description: >-

--- a/packages/leancode_hooks/CHANGELOG.md
+++ b/packages/leancode_hooks/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.0.3+1
+
+- Fix build badge in README.
+
 # 0.0.3
 
 - Add tests for `useThrottle`

--- a/packages/leancode_hooks/README.md
+++ b/packages/leancode_hooks/README.md
@@ -4,9 +4,7 @@
 discoverability and consistent versioning.
 
 [![leancode_hooks pub.dev badge][pub-badge]][pub-badge-link]
-
-[pub-badge]: https://img.shields.io/pub/v/leancode_hooks
-[pub-badge-link]: https://pub.dev/packages/leancode_hooks
+[![][build-badge]][build-badge-link]
 
 ## Usage
 
@@ -30,3 +28,7 @@ so you won't have to depend on it.
 - [useThrottle](lib/src/use_throttle.dart)
 
 [flutter_hooks]: https://pub.dev/packages/flutter_hooks
+[pub-badge]: https://img.shields.io/pub/v/leancode_hooks
+[pub-badge-link]: https://pub.dev/packages/leancode_hooks
+[build-badge]: https://img.shields.io/github/actions/workflow/status/leancodepl/flutter_corelibrary/leancode_hooks-test.yml?branch=master
+[build-badge-link]: https://github.com/leancodepl/flutter_corelibrary/actions/workflows/leancode_hooks-test.yml

--- a/packages/leancode_hooks/pubspec.yaml
+++ b/packages/leancode_hooks/pubspec.yaml
@@ -1,5 +1,5 @@
 name: leancode_hooks
-version: 0.0.3
+version: 0.0.3+1
 homepage: https://github.com/leancodepl/flutter_corelibrary/tree/master/packages/leancode_hooks
 repository: https://github.com/leancodepl/flutter_corelibrary
 description: >-

--- a/packages/leancode_hooks/pubspec.yaml
+++ b/packages/leancode_hooks/pubspec.yaml
@@ -19,4 +19,4 @@ dev_dependencies:
   coverage: ^1.2.0
   flutter_test:
     sdk: flutter
-  leancode_lint: ^1.1.0
+  leancode_lint: '>=1.0.2 <1.1.0'

--- a/packages/login_client/CHANGELOG.md
+++ b/packages/login_client/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.1.0+1
+
+- Fix build badge in README.
+
 # 2.1.0
 
 - Bumped `build_runner` dependency to `2.0.0`

--- a/packages/login_client/README.md
+++ b/packages/login_client/README.md
@@ -37,7 +37,7 @@ For Flutter implementation of the `CredentialsStorage`, check out [`login_client
 [pub-badge-link]: https://pub.dev/packages/login_client
 [build-badge]: https://img.shields.io/github/workflow/status/leancodepl/flutter_corelibrary/login_client%20test
 [build-badge-link]: https://github.com/leancodepl/flutter_corelibrary/actions?query=workflow%3A%22login_client+test%22
-[codecov-badge]: https://img.shields.io/codecov/c/gh/leancodepl/flutter_corelibrary?flag=login_client
-[codecov-badge-link]: https://codecov.io/gh/leancodepl/flutter_corelibrary
+[build-badge]: https://img.shields.io/github/actions/workflow/status/leancodepl/flutter_corelibrary/login_client-test.yml?branch=master
+[build-badge-link]: https://github.com/leancodepl/flutter_corelibrary/actions/workflows/login_client-test.yml
 [snippet]: assets/snippet.png
 [login_client_flutter]: https://pub.dev/packages/login_client_flutter

--- a/packages/login_client/pubspec.yaml
+++ b/packages/login_client/pubspec.yaml
@@ -1,5 +1,5 @@
 name: login_client
-version: 2.1.0
+version: 2.1.0+1
 homepage: https://github.com/leancodepl/flutter_corelibrary/tree/master/packages/login_client
 repository: https://github.com/leancodepl/flutter_corelibrary
 description: >-

--- a/packages/login_client/pubspec.yaml
+++ b/packages/login_client/pubspec.yaml
@@ -19,6 +19,6 @@ dependencies:
 dev_dependencies:
   build_runner: ^2.0.0
   coverage: ^1.0.3
-  leancode_lint: ^1.0.2
+  leancode_lint: '>=1.0.2 <1.1.0'
   mockito: ^5.0.0
   test: ^1.16.4

--- a/packages/login_client_flutter/CHANGELOG.md
+++ b/packages/login_client_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.0.1+1
+
+- Fix build badge in README.
+
 # 2.0.1
 
 - Increase `flutter_secure_storage` version range to `>=4.2.0 <6.0.0`.

--- a/packages/login_client_flutter/README.md
+++ b/packages/login_client_flutter/README.md
@@ -1,7 +1,7 @@
 # login_client_flutter
 
-[![login_client_flutter pub.dev badge][login_client_flutter-pub-badge]][login_client_flutter-pub-badge-link]
-[![login_client_flutter continuous integration badge][login_client_flutter-build-badge]][login_client_flutter-build-badge-link]
+[![login_client_flutter pub.dev badge][pub-badge]][pub-badge-link]
+[![login_client_flutter continuous integration badge][build-badge]][build-badge-link]
 
 [flutter_secure_storage] implementation of a `CredentialsStorage` for the [login_client] package.
 
@@ -35,9 +35,9 @@ Exclude Flutter Secure Storage from Android full backup.
 </full-backup-content>
 ```
 
-[login_client_flutter-pub-badge]: https://img.shields.io/pub/v/login_client_flutter
-[login_client_flutter-pub-badge-link]: https://pub.dev/packages/login_client_flutter
-[login_client_flutter-build-badge]: https://img.shields.io/github/workflow/status/leancodepl/flutter_corelibrary/login_client_flutter%20test
-[login_client_flutter-build-badge-link]: https://github.com/leancodepl/flutter_corelibrary/actions?query=workflow%3A%22login_client_flutter+test%22
+[pub-badge]: https://img.shields.io/pub/v/login_client_flutter
+[pub-badge-link]: https://pub.dev/packages/login_client_flutter
+[build-badge]: https://img.shields.io/github/actions/workflow/status/leancodepl/flutter_corelibrary/login_client_flutter-test.yml?branch=master
+[build-badge-link]: https://github.com/leancodepl/flutter_corelibrary/actions/workflows/login_client_flutter-test.yml
 [flutter_secure_storage]: https://github.com/mogol/flutter_secure_storage
 [login_client]: https://github.com/leancodepl/flutter_corelibrary/tree/master/packages/login_client

--- a/packages/login_client_flutter/pubspec.yaml
+++ b/packages/login_client_flutter/pubspec.yaml
@@ -17,4 +17,4 @@ dependencies:
   login_client: ^2.0.1
 
 dev_dependencies:
-  leancode_lint: ^1.0.2
+  leancode_lint: '>=1.0.2 <1.1.0'

--- a/packages/login_client_flutter/pubspec.yaml
+++ b/packages/login_client_flutter/pubspec.yaml
@@ -1,5 +1,5 @@
 name: login_client_flutter
-version: 2.0.1
+version: 2.0.1+1
 homepage: https://github.com/leancodepl/flutter_corelibrary/tree/master/packages/login_client_flutter
 repository: https://github.com/leancodepl/flutter_corelibrary
 description: >-

--- a/packages/override_api_endpoint/CHANGELOG.md
+++ b/packages/override_api_endpoint/CHANGELOG.md
@@ -1,3 +1,7 @@
-# 1.0.0
+# 1.0.0+2
+
+- Fix build badge in README.
+
+# 1.0.0+1
 
 - Initial release

--- a/packages/override_api_endpoint/README.md
+++ b/packages/override_api_endpoint/README.md
@@ -31,6 +31,6 @@ final apiEndpoint = await overrideApiEndpoint(
 ```
 [pub-badge]: https://img.shields.io/pub/v/override_api_endpoint
 [pub-badge-link]: https://pub.dev/packages/override_api_endpoint
-[build-badge]: https://img.shields.io/github/workflow/status/leancodepl/flutter_corelibrary/override_api_endpoint%20test
-[build-badge-link]: https://github.com/leancodepl/flutter_corelibrary/actions?query=workflow%3A%22override_api_endpoint+test%22
+[build-badge]: https://img.shields.io/github/actions/workflow/status/leancodepl/flutter_corelibrary/override_api_endpoint-test.yml?branch=master
+[build-badge-link]: https://github.com/leancodepl/flutter_corelibrary/actions/workflows/override_api_endpoint-test.yml
 [override_api_endpoint_flutter]: https://pub.dev/packages/override_api_endpoint_flutter

--- a/packages/override_api_endpoint/pubspec.yaml
+++ b/packages/override_api_endpoint/pubspec.yaml
@@ -1,5 +1,5 @@
 name: override_api_endpoint
-version: 1.0.0+1
+version: 1.0.0+2
 homepage: https://github.com/leancodepl/flutter_corelibrary/tree/master/packages/override_api_endpoint
 repository: https://github.com/leancodepl/flutter_corelibrary
 description: >-


### PR DESCRIPTION
* Fixed build badges in packages READMEs and in main README
* Instead of `beta` and `stable` channels, explicit latest stable version (3.3) is used in CI
* Make Codecov informational, so it won't fail the CI