### PR TITLE
Remove library_private_types_in_public_api

### DIFF
--- a/packages/leancode_lint/CHANGELOG.md
+++ b/packages/leancode_lint/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.0.0+1
+
+- Remove lint [`library_private_types_in_public_api`](https://dart-lang.github.io/linter/lints/library_private_types_in_public_api.html) which was accidentally enabled
+
 # 4.0.0
 
 - Enable the following lints:

--- a/packages/leancode_lint/lib/analysis_options.yaml
+++ b/packages/leancode_lint/lib/analysis_options.yaml
@@ -73,7 +73,6 @@ linter:
     - library_annotations
     - library_names
     - library_prefixes
-    - library_private_types_in_public_api
     - list_remove_unrelated_type
     - literal_only_boolean_expressions
     - no_adjacent_strings_in_list

--- a/packages/leancode_lint/lib/analysis_options_package.yaml
+++ b/packages/leancode_lint/lib/analysis_options_package.yaml
@@ -2,5 +2,5 @@ include: package:leancode_lint/analysis_options.yaml
 
 linter:
   rules:
-    package_api_docs: true
-    public_member_api_docs: true
+    - package_api_docs
+    - public_member_api_docs

--- a/packages/leancode_lint/pubspec.yaml
+++ b/packages/leancode_lint/pubspec.yaml
@@ -1,5 +1,5 @@
 name: leancode_lint
-version: 4.0.0
+version: 4.0.0+1
 homepage: https://github.com/leancodepl/flutter_corelibrary/tree/master/packages/leancode_lint
 repository: https://github.com/leancodepl/flutter_corelibrary
 description: Lint rules used at LeanCode.


### PR DESCRIPTION
It got added by accident when removing `flutter_lints`