### PR TITLE
Make usePostFrameEffect accept nullable keys

### DIFF
--- a/packages/leancode_hooks/CHANGELOG.md
+++ b/packages/leancode_hooks/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.0.4
+
+- Make `usePostFrameEffect` accept nullable keys.
+
 # 0.0.3+1
 
 - Fix build badge in README.

--- a/packages/leancode_hooks/lib/src/use_post_frame_effect.dart
+++ b/packages/leancode_hooks/lib/src/use_post_frame_effect.dart
@@ -3,7 +3,7 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 
 /// Registers [effect] to be run in
 /// WidgetsBinding.instance.addPostFrameCallback.
-void usePostFrameEffect(VoidCallback effect, [List<Object>? keys]) {
+void usePostFrameEffect(VoidCallback effect, [List<Object?>? keys]) {
   useEffect(
     () {
       WidgetsBinding.instance.addPostFrameCallback((_) => effect());

--- a/packages/leancode_hooks/pubspec.yaml
+++ b/packages/leancode_hooks/pubspec.yaml
@@ -1,5 +1,5 @@
 name: leancode_hooks
-version: 0.0.3+2
+version: 0.0.4
 homepage: https://github.com/leancodepl/flutter_corelibrary/tree/master/packages/leancode_hooks
 repository: https://github.com/leancodepl/flutter_corelibrary
 description: >-

--- a/packages/leancode_hooks/test/use_post_frame_effect_test.dart
+++ b/packages/leancode_hooks/test/use_post_frame_effect_test.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:leancode_hooks/leancode_hooks.dart';
+
+class UsePostFrameEffectTestWidget extends HookWidget {
+  const UsePostFrameEffectTestWidget({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final called = useState(false);
+
+    usePostFrameEffect(
+      () => called.value = true,
+    );
+
+    return MaterialApp(
+      home: Text(called.value.toString()),
+    );
+  }
+}
+
+void main() {
+  testWidgets('effect gets called post frame', (tester) async {
+    await tester.pumpWidget(const UsePostFrameEffectTestWidget());
+
+    expect(find.text('true'), findsNothing);
+
+    tester.binding.scheduleWarmUpFrame();
+
+    expect(find.text('true'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
usePostFrameEffect should accept nullable keys just as the original useEffect does