### PR TITLE
Bump package:http to v1 in packages

### DIFF
--- a/.github/workflows/cqrs-publish.yml
+++ b/.github/workflows/cqrs-publish.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Dart
         uses: dart-lang/setup-dart@v1
         with:
-          sdk: 2.18.6
+          sdk: 3.0.1
 
       - name: Publish
         run: dart pub publish -f

--- a/.github/workflows/cqrs-test.yml
+++ b/.github/workflows/cqrs-test.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        dart_release: ['2.17.0']
+        dart_release: ['3.0.1']
 
     defaults:
       run:

--- a/.github/workflows/login_client-publish.yml
+++ b/.github/workflows/login_client-publish.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Dart
         uses: dart-lang/setup-dart@v1
         with:
-          sdk: 2.18.6
+          sdk: 3.0.1
 
       - name: Publish
         run: dart pub publish -f

--- a/.github/workflows/login_client-test.yml
+++ b/.github/workflows/login_client-test.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        dart_release: ['2.14.0']
+        dart_release: ['3.0.1']
 
     defaults:
       run:

--- a/.github/workflows/login_client-test.yml
+++ b/.github/workflows/login_client-test.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Run tests with coverage
         run: |
           dart test --coverage=coverage
-          dart run coverage:format_coverage --lcov --in=coverage --out=coverage/lcov.info --packages=.packages --report-on=lib
+          dart run coverage:format_coverage --lcov --in=coverage --out=coverage/lcov.info --report-on=lib
 
       - name: Dry run pub publish
         # We don't want it to fail the CI, it's just to see how would `pub publish` behave.

--- a/packages/cqrs/CHANGELOG.md
+++ b/packages/cqrs/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 9.0.0
+
+- Bumped `http` dependency to `1.0.0`.
+
 # 8.0.0+1
 
 - Fix build badge in README.

--- a/packages/cqrs/CHANGELOG.md
+++ b/packages/cqrs/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 9.0.0
 
 - Bumped `http` dependency to `1.0.0`.
+- **Breaking:** Bump minimum Dart version to 3.0.
 
 # 8.0.0+1
 

--- a/packages/cqrs/CHANGELOG.md
+++ b/packages/cqrs/CHANGELOG.md
@@ -1,7 +1,7 @@
 # 9.0.0
 
-- Bumped `http` dependency to `1.0.0`.
-- **Breaking:** Bump minimum Dart version to 3.0.
+- Bumped `http` dependency to `1.0.0`. (#105)
+- **Breaking:** Bump minimum Dart version to 3.0. (#105)
 
 # 8.0.0+1
 

--- a/packages/cqrs/pubspec.yaml
+++ b/packages/cqrs/pubspec.yaml
@@ -7,14 +7,14 @@ description: >-
   queries and commands.
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
+  sdk: '>=3.0.1 <4.0.0'
 
 dependencies:
-  http: ^0.13.3
+  http: ^1.0.0
 
 dev_dependencies:
   build_runner: ^2.0.4
   coverage: ^1.5.0
-  leancode_lint: ^1.2.1
+  leancode_lint: ^4.0.0+1
   mockito: ^5.0.9
   test: ^1.17.5

--- a/packages/cqrs/pubspec.yaml
+++ b/packages/cqrs/pubspec.yaml
@@ -1,5 +1,5 @@
 name: cqrs
-version: 8.0.0+2
+version: 9.0.0
 homepage: https://github.com/leancodepl/flutter_corelibrary/tree/master/packages/cqrs
 repository: https://github.com/leancodepl/flutter_corelibrary
 description: >-

--- a/packages/login_client/CHANGELOG.md
+++ b/packages/login_client/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.0.0
+
+- Bumped `http` dependency to `1.0.0`
+
 # 2.1.0+2
 
 - Fix accidentally removed codecov badge from README.

--- a/packages/login_client/CHANGELOG.md
+++ b/packages/login_client/CHANGELOG.md
@@ -1,7 +1,7 @@
 # 3.0.0
 
-- Bumped `http` dependency to `1.0.0`.
-- **Breaking:** Bump minimum Dart version to 3.0.
+- Bumped `http` dependency to `1.0.0`. (#105)
+- **Breaking:** Bump minimum Dart version to 3.0. (#105)
 
 # 2.1.0+2
 

--- a/packages/login_client/CHANGELOG.md
+++ b/packages/login_client/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 3.0.0
 
-- Bumped `http` dependency to `1.0.0`
+- Bumped `http` dependency to `1.0.0`.
+- **Breaking:** Bump minimum Dart version to 3.0.
 
 # 2.1.0+2
 

--- a/packages/login_client/lib/login_client.dart
+++ b/packages/login_client/lib/login_client.dart
@@ -16,7 +16,7 @@
 library login_client;
 
 export 'package:oauth2/oauth2.dart'
-    show Credentials, AuthorizationException, ExpirationException;
+    show AuthorizationException, Credentials, ExpirationException;
 
 export 'src/credentials_storage/credentials_storage.dart';
 export 'src/credentials_storage/in_memory_credentials_storage.dart';

--- a/packages/login_client/pubspec.yaml
+++ b/packages/login_client/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.0.0
-  coverage: ^1.0.3
+  coverage: ^1.6.3
   leancode_lint: ^4.0.0+1
   mockito: ^5.0.0
   test: ^1.16.4

--- a/packages/login_client/pubspec.yaml
+++ b/packages/login_client/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
   sdk: '>=3.0.1 <4.0.0'
 
 dependencies:
-  http: ^0.13.0
+  http: ^1.0.0
   http_parser: ^4.0.0
   meta: ^1.3.0
   oauth2: ^2.0.0

--- a/packages/login_client/pubspec.yaml
+++ b/packages/login_client/pubspec.yaml
@@ -8,7 +8,7 @@ description: >-
   refreshes tokens.
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=3.0.1 <4.0.0'
 
 dependencies:
   http: ^0.13.0
@@ -19,6 +19,6 @@ dependencies:
 dev_dependencies:
   build_runner: ^2.0.0
   coverage: ^1.0.3
-  leancode_lint: '>=1.0.2 <1.1.0'
+  leancode_lint: ^4.0.0+1
   mockito: ^5.0.0
   test: ^1.16.4

--- a/packages/login_client/pubspec.yaml
+++ b/packages/login_client/pubspec.yaml
@@ -1,5 +1,5 @@
 name: login_client
-version: 2.1.0+3
+version: 3.0.0
 homepage: https://github.com/leancodepl/flutter_corelibrary/tree/master/packages/login_client
 repository: https://github.com/leancodepl/flutter_corelibrary
 description: >-

--- a/packages/login_client/test/login_client_test.dart
+++ b/packages/login_client/test/login_client_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:http/http.dart'
     show
         BaseRequest,
@@ -5,7 +7,6 @@ import 'package:http/http.dart'
         Request,
         StreamedRequest,
         StreamedResponse;
-import 'package:leancode_lint/leancode_lint.dart';
 import 'package:login_client/login_client.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';

--- a/packages/login_client/test/login_client_test.mocks.dart
+++ b/packages/login_client/test/login_client_test.mocks.dart
@@ -28,8 +28,8 @@ class _FakeClient_0 extends _i1.Fake implements _i2.Client {}
 
 class _FakeCredentials_1 extends _i1.Fake implements _i2.Credentials {}
 
-class _FakeStreamedResponse_2 extends _i1.Fake implements _i3.StreamedResponse {
-}
+class _FakeStreamedResponse_2 extends _i1.Fake
+    implements _i3.StreamedResponse {}
 
 class _FakeResponse_3 extends _i1.Fake implements _i3.Response {}
 


### PR DESCRIPTION
Since we are requiring dart 3 here, maybe it is worth revisiting the API to modernize for records/class modifiers?