### PR TITLE
TapAnalyticsEvent need String instead of ValueKey

### DIFF
--- a/packages/leancode_analytics/README.md
+++ b/packages/leancode_analytics/README.md
@@ -45,7 +45,7 @@ Register tap event in all your tappable widgets:
 ```dart
 context.read<LeanAnalytics>().register(
     TapAnalyticsEvent(
-        key: key! as ValueKey<String>,
+        key: key,
         label: label,
     ),
 );

--- a/packages/leancode_analytics/lib/core/event.dart
+++ b/packages/leancode_analytics/lib/core/event.dart
@@ -61,7 +61,7 @@ class TapAnalyticsEvent extends AnalyticsEvent {
   /// Create [TapAnalyticsEvent] with [key], tapped element [label]
   /// and optional [params]
   TapAnalyticsEvent({
-    required ValueKey<String> key,
+    required String key,
     required String? label,
     Map<String, Object> params = const {},
   })  : assert(
@@ -76,8 +76,8 @@ class TapAnalyticsEvent extends AnalyticsEvent {
           name: 'tap',
           params: {
             ...params,
-            'key': key.value,
-            if (label != null) 'label': label
+            'key': key,
+            if (label != null) 'label': label,
           },
         );
 }

--- a/packages/leancode_analytics/pubspec.yaml
+++ b/packages/leancode_analytics/pubspec.yaml
@@ -1,6 +1,6 @@
 name: leancode_analytics
 description: A new Flutter package project.
-version: 0.0.1
+version: 0.0.2
 homepage:
 
 environment:


### PR DESCRIPTION
As in the title. We change the approach for passing analytics id key. Required to add analytics to leancode_flutter_template