### PR TITLE
Fix cqrs v10.0.0 issues

### DIFF
--- a/packages/cqrs/CHANGELOG.md
+++ b/packages/cqrs/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 10.0.1
+
+- **Breaking:** Rename `forbiddenAccess` to `authorization` in error enums.
+- Update error enums docs.
+- Fix `CqrsMiddleware` not being exported from the package.
+
 # 10.0.0
 
 - **Breaking:** Fundamentaly change overall `Cqrs` API making it no-throw guarantee.

--- a/packages/cqrs/CHANGELOG.md
+++ b/packages/cqrs/CHANGELOG.md
@@ -3,6 +3,7 @@
 - **Breaking:** Rename `forbiddenAccess` to `authorization` in error enums.
 - Update error enums docs.
 - Fix `CqrsMiddleware` not being exported from the package.
+- Move `hasError` and `hasErrorForProperty` from `CommandResponse` to `CommandFailure`.
 
 # 10.0.0
 

--- a/packages/cqrs/CHANGELOG.md
+++ b/packages/cqrs/CHANGELOG.md
@@ -13,9 +13,9 @@
 - Add middleware mechanism in form of `CqrsMiddleware` intended to use in processing result from queries, commands and operations.
 - **Breaking:** Remove `CqrsException`.
 - **Breaking:** Rename previous `CommandResult` to `CommandResponse` and make it package private.
-- Mark the `CqrsMethod` as `sealed`.
-- **Breaking:** Make `ValidationError` extend `Equatable` from `equatable` package.
-- **Breaking:** Add `equatable` (`^2.0.5`) and `logging` (`^1.2.0`) dependencies.
+- **Breaking:** Mark the `CqrsMethod` as `sealed`.
+- Make `ValidationError` extend `Equatable` from `equatable` package.
+- Add `equatable` (`^2.0.5`) and `logging` (`^1.2.0`) dependencies.
 
 # 9.0.0
 

--- a/packages/cqrs/CHANGELOG.md
+++ b/packages/cqrs/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 # 10.0.0
 
+**Retracted.**
+
 - **Breaking:** Fundamentaly change overall `Cqrs` API making it no-throw guarantee.
 - **Breaking:** Make `Cqrs.get`, `Cqrs.run` and `Cqrs.perform` return result data in form of `QueryResult`, `CommandResult` and `OperationResult` respectively.
 - Add `logger` parameter (of type `Logger` from `logging` package) to `Cqrs` default constructor. If provided, the `logger` will be used as a debug logging interface in execution of CQRS methods.

--- a/packages/cqrs/lib/cqrs.dart
+++ b/packages/cqrs/lib/cqrs.dart
@@ -66,6 +66,7 @@ library;
 
 export 'src/cqrs.dart';
 export 'src/cqrs_error.dart';
+export 'src/cqrs_middleware.dart';
 export 'src/cqrs_result.dart';
 export 'src/transport_types.dart';
 export 'src/validation_error.dart';

--- a/packages/cqrs/lib/src/command_response.dart
+++ b/packages/cqrs/lib/src/command_response.dart
@@ -44,15 +44,6 @@ class CommandResponse {
   /// Validation errors related to the data carried by the [Command].
   final List<ValidationError> errors;
 
-  /// Checks whether this [CommandResponse] contains a provided error `code` in
-  /// its validation errors.
-  bool hasError(int code) => errors.any((error) => error.code == code);
-
-  /// Checks whether this [CommandResponse] contains a provided error `code` in
-  /// its validation errors related to the `propertyName`.
-  bool hasErrorForProperty(int code, String propertyName) => errors
-      .any((error) => error.code == code && error.propertyName == propertyName);
-
   /// Serializes this [CommandResponse] to JSON.
   Map<String, dynamic> toJson() => <String, dynamic>{
         'WasSuccessful': success,

--- a/packages/cqrs/lib/src/cqrs.dart
+++ b/packages/cqrs/lib/src/cqrs.dart
@@ -31,7 +31,7 @@ enum _ResultType {
   jsonError,
   networkError,
   authenticationError,
-  forbiddenAccessError,
+  authorizationError,
   validationError,
   unknownError;
 
@@ -40,7 +40,7 @@ enum _ResultType {
         jsonError => 'failed while decoding response body JSON',
         networkError => 'failed with network error',
         authenticationError => 'failed with authentication error',
-        forbiddenAccessError => 'failed with forbidden access error',
+        authorizationError => 'failed with authorization error',
         validationError => 'failed with validation errors',
         unknownError => 'failed unexpectedly',
       };
@@ -190,8 +190,8 @@ class Cqrs {
         return QueryFailure<T>(QueryError.authentication);
       }
       if (response.statusCode == 403) {
-        _log(query, _ResultType.forbiddenAccessError);
-        return QueryFailure<T>(QueryError.forbiddenAccess);
+        _log(query, _ResultType.authorizationError);
+        return QueryFailure<T>(QueryError.authorization);
       }
     } on SocketException catch (e, s) {
       _log(query, _ResultType.networkError, e, s);
@@ -241,8 +241,8 @@ class Cqrs {
         return const CommandFailure(CommandError.authentication);
       }
       if (response.statusCode == 403) {
-        _log(command, _ResultType.forbiddenAccessError);
-        return const CommandFailure(CommandError.forbiddenAccess);
+        _log(command, _ResultType.authorizationError);
+        return const CommandFailure(CommandError.authorization);
       }
     } on SocketException catch (e, s) {
       _log(command, _ResultType.networkError, e, s);
@@ -281,8 +281,8 @@ class Cqrs {
         return OperationFailure<T>(OperationError.authentication);
       }
       if (response.statusCode == 403) {
-        _log(operation, _ResultType.forbiddenAccessError);
-        return OperationFailure<T>(OperationError.forbiddenAccess);
+        _log(operation, _ResultType.authorizationError);
+        return OperationFailure<T>(OperationError.authorization);
       }
     } on SocketException catch (e, s) {
       _log(operation, _ResultType.networkError, e, s);
@@ -330,7 +330,7 @@ class Cqrs {
       _ResultType.jsonError ||
       _ResultType.networkError ||
       _ResultType.authenticationError ||
-      _ResultType.forbiddenAccessError ||
+      _ResultType.authorizationError ||
       _ResultType.unknownError =>
         logger.severe,
     };

--- a/packages/cqrs/lib/src/cqrs_error.dart
+++ b/packages/cqrs/lib/src/cqrs_error.dart
@@ -17,11 +17,11 @@ enum QueryError {
   /// Represents a network/socket error.
   network,
 
-  /// Represents a HTTP 401 authentication error.
+  /// Represents an authentication error.
   authentication,
 
-  /// Represents a HTTP 403 forbidden access error.
-  forbiddenAccess,
+  /// Represents an authorization error.
+  authorization,
 
   /// Represents a generic error which covers all remaining errors.
   unknown,
@@ -32,13 +32,13 @@ enum CommandError {
   /// Represents a network/socket error.
   network,
 
-  /// Represents a HTTP 401 authentication error.
+  /// Represents an authentication error.
   authentication,
 
-  /// Represents a HTTP 403 forbidden access error.
-  forbiddenAccess,
+  /// Represents an authorization error.
+  authorization,
 
-  /// Represents a HTTP 422 validation error.
+  /// Represents a validation error.
   validation,
 
   /// Represents a generic error which covers all remaining errors.
@@ -50,11 +50,11 @@ enum OperationError {
   /// Represents a network/socket error.
   network,
 
-  /// Represents a HTTP 401 authentication error.
+  /// Represents an authentication error.
   authentication,
 
-  /// Represents a HTTP 403 forbidden access error.
-  forbiddenAccess,
+  /// Represents an authorization error.
+  authorization,
 
   /// Represents a generic error which covers all remaining errors.
   unknown,

--- a/packages/cqrs/lib/src/cqrs_result.dart
+++ b/packages/cqrs/lib/src/cqrs_result.dart
@@ -54,7 +54,7 @@ final class QueryFailure<T> extends QueryResult<T> {
   List<Object?> get props => [error];
 }
 
-/// Generic result for CQRS command result. Can be either [CommandSuccess]
+/// Result class for CQRS command result. Can be either [CommandSuccess]
 /// or [CommandFailure].
 sealed class CommandResult extends Equatable {
   /// Creates a [CommandResult] class.
@@ -74,7 +74,7 @@ sealed class CommandResult extends Equatable {
       };
 }
 
-/// Generic class which represents a result of succesful command execution.
+/// Class which represents a result of succesful command execution.
 final class CommandSuccess extends CommandResult {
   /// Creates a [CommandSuccess] class.
   const CommandSuccess();
@@ -83,7 +83,7 @@ final class CommandSuccess extends CommandResult {
   List<Object?> get props => [];
 }
 
-/// Generic class which represents a result of unsuccesful command execution.
+/// Class which represents a result of unsuccesful command execution.
 final class CommandFailure extends CommandResult {
   /// Creates a [CommandFailure] class.
   const CommandFailure(

--- a/packages/cqrs/lib/src/cqrs_result.dart
+++ b/packages/cqrs/lib/src/cqrs_result.dart
@@ -98,13 +98,13 @@ final class CommandFailure extends CommandResult {
   /// command execution.
   final List<ValidationError> validationErrors;
 
-  /// Checks whether this [CommandFailure] contains a provided validationErrors
-  /// `code` in its validation errors.
+  /// Checks whether this [CommandFailure] contains a provided error `code` in
+  /// its validation errors.
   bool hasError(int code) =>
       validationErrors.any((error) => error.code == code);
 
-  /// Checks whether this [CommandFailure] contains a provided validationErrors
-  /// `code` in its validation errors related to the `propertyName`.
+  /// Checks whether this [CommandFailure] contains a provided error `code` in
+  /// its validation errors related to the `propertyName`.
   bool hasErrorForProperty(int code, String propertyName) => validationErrors
       .any((error) => error.code == code && error.propertyName == propertyName);
 

--- a/packages/cqrs/lib/src/cqrs_result.dart
+++ b/packages/cqrs/lib/src/cqrs_result.dart
@@ -98,6 +98,16 @@ final class CommandFailure extends CommandResult {
   /// command execution.
   final List<ValidationError> validationErrors;
 
+  /// Checks whether this [CommandFailure] contains a provided validationErrors
+  /// `code` in its validation errors.
+  bool hasError(int code) =>
+      validationErrors.any((error) => error.code == code);
+
+  /// Checks whether this [CommandFailure] contains a provided validationErrors
+  /// `code` in its validation errors related to the `propertyName`.
+  bool hasErrorForProperty(int code, String propertyName) => validationErrors
+      .any((error) => error.code == code && error.propertyName == propertyName);
+
   @override
   List<Object?> get props => [error, validationErrors];
 }

--- a/packages/cqrs/pubspec.yaml
+++ b/packages/cqrs/pubspec.yaml
@@ -1,5 +1,5 @@
 name: cqrs
-version: 10.0.0
+version: 10.0.1
 homepage: https://github.com/leancodepl/flutter_corelibrary/tree/master/packages/cqrs
 repository: https://github.com/leancodepl/flutter_corelibrary
 description: >-

--- a/packages/cqrs/test/command_response_test.dart
+++ b/packages/cqrs/test/command_response_test.dart
@@ -41,49 +41,6 @@ void main() {
       });
     });
 
-    group('hasError returns correct values', () {
-      test('when there are some errors present', () {
-        const result = CommandResponse([error1, error2]);
-
-        expect(result.hasError(1), true);
-        expect(result.hasError(2), true);
-        expect(result.hasError(3), false);
-      });
-
-      test('when there are no errors present', () {
-        const result = CommandResponse([]);
-
-        expect(result.hasError(1), false);
-        expect(result.hasError(2), false);
-        expect(result.hasError(3), false);
-      });
-    });
-
-    group('hasErrorForProperty returns correct values', () {
-      test('when there are some errors present', () {
-        const result = CommandResponse([error1, error2]);
-
-        expect(result.hasErrorForProperty(1, 'Property1'), true);
-        expect(result.hasErrorForProperty(2, 'Property2'), true);
-      });
-
-      test('when there are errors but for different properties', () {
-        const result = CommandResponse([error1, error2]);
-
-        expect(result.hasErrorForProperty(1, 'Property2'), false);
-        expect(result.hasErrorForProperty(2, 'Property1'), false);
-      });
-
-      test('when there are no errors present', () {
-        const result = CommandResponse([]);
-
-        expect(result.hasErrorForProperty(1, 'Property1'), false);
-        expect(result.hasErrorForProperty(2, 'Property1'), false);
-        expect(result.hasErrorForProperty(2, 'Property1'), false);
-        expect(result.hasErrorForProperty(2, 'Property2'), false);
-      });
-    });
-
     group('is correctly deserialized from JSON', () {
       test('with some validation errors', () {
         final result = CommandResponse.fromJson(<String, dynamic>{

--- a/packages/cqrs/test/cqrs_middleware_test.dart
+++ b/packages/cqrs/test/cqrs_middleware_test.dart
@@ -1,5 +1,4 @@
 import 'package:cqrs/cqrs.dart';
-import 'package:cqrs/src/cqrs_middleware.dart';
 import 'package:test/test.dart';
 
 void main() {

--- a/packages/cqrs/test/cqrs_result_test.dart
+++ b/packages/cqrs/test/cqrs_result_test.dart
@@ -2,6 +2,9 @@ import 'package:cqrs/cqrs.dart';
 import 'package:test/test.dart';
 
 void main() {
+  const error1 = ValidationError(1, 'First error', 'Property1');
+  const error2 = ValidationError(2, 'Second error', 'Property2');
+
   group('QueryResult', () {
     group('fields values are correct', () {
       test('when constructed as success', () {
@@ -46,20 +49,66 @@ void main() {
       test('when constructed as failure with validation errors', () {
         const result = CommandFailure(
           CommandError.validation,
-          validationErrors: [
-            ValidationError(123, 'Test message', 'SomeProperty'),
-            ValidationError(456, 'Another message', 'OtherProperty'),
-          ],
+          validationErrors: [error1, error2],
         );
 
         expect(result.isSuccess, false);
         expect(result.isFailure, true);
         expect(result.isInvalid, true);
-        expect(result.validationErrors, const <ValidationError>[
-          ValidationError(123, 'Test message', 'SomeProperty'),
-          ValidationError(456, 'Another message', 'OtherProperty'),
-        ]);
+        expect(result.validationErrors, const [error1, error1]);
         expect(result.error, CommandError.validation);
+      });
+
+      group('hasError returns correct values', () {
+        test('when there are some errors present', () {
+          const result = CommandFailure(
+            CommandError.validation,
+            validationErrors: [error1, error2],
+          );
+
+          expect(result.hasError(1), true);
+          expect(result.hasError(2), true);
+          expect(result.hasError(3), false);
+        });
+
+        test('when there are no errors present', () {
+          const result = CommandFailure(CommandError.unknown);
+
+          expect(result.hasError(1), false);
+          expect(result.hasError(2), false);
+          expect(result.hasError(3), false);
+        });
+      });
+
+      group('hasErrorForProperty returns correct values', () {
+        test('when there are some errors present', () {
+          const result = CommandFailure(
+            CommandError.validation,
+            validationErrors: [error1, error2],
+          );
+
+          expect(result.hasErrorForProperty(1, 'Property1'), true);
+          expect(result.hasErrorForProperty(2, 'Property2'), true);
+        });
+
+        test('when there are errors but for different properties', () {
+          const result = CommandFailure(
+            CommandError.validation,
+            validationErrors: [error1, error2],
+          );
+
+          expect(result.hasErrorForProperty(1, 'Property2'), false);
+          expect(result.hasErrorForProperty(2, 'Property1'), false);
+        });
+
+        test('when there are no errors present', () {
+          const result = CommandFailure(CommandError.unknown);
+
+          expect(result.hasErrorForProperty(1, 'Property1'), false);
+          expect(result.hasErrorForProperty(2, 'Property1'), false);
+          expect(result.hasErrorForProperty(2, 'Property1'), false);
+          expect(result.hasErrorForProperty(2, 'Property2'), false);
+        });
       });
     });
   });

--- a/packages/cqrs/test/cqrs_result_test.dart
+++ b/packages/cqrs/test/cqrs_result_test.dart
@@ -55,7 +55,7 @@ void main() {
         expect(result.isSuccess, false);
         expect(result.isFailure, true);
         expect(result.isInvalid, true);
-        expect(result.validationErrors, const [error1, error1]);
+        expect(result.validationErrors, const [error1, error2]);
         expect(result.error, CommandError.validation);
       });
 

--- a/packages/cqrs/test/cqrs_test.dart
+++ b/packages/cqrs/test/cqrs_test.dart
@@ -224,7 +224,7 @@ void main() {
       });
 
       test(
-          'returns QueryFailure(QueryError.forbiddenAccess) when response'
+          'returns QueryFailure(QueryError.authorization) when response'
           ' code is 403 and logs result', () async {
         mockClientPost(client, Response('', 403));
 
@@ -232,12 +232,12 @@ void main() {
 
         expect(
           result,
-          const QueryFailure<bool?>(QueryError.forbiddenAccess),
+          const QueryFailure<bool?>(QueryError.authorization),
         );
 
         verify(
           () => logger.severe(
-            'Query ExampleQuery failed with forbidden access error.',
+            'Query ExampleQuery failed with authorization error.',
             any(),
             any(),
           ),
@@ -450,7 +450,7 @@ void main() {
       });
 
       test(
-          'returns CommandFailure(CommandError.forbiddenAccess) when'
+          'returns CommandFailure(CommandError.authorization) when'
           ' response code is 403 and logs result', () async {
         mockClientPost(client, Response('', 403));
 
@@ -458,12 +458,12 @@ void main() {
 
         expect(
           result,
-          const CommandFailure(CommandError.forbiddenAccess),
+          const CommandFailure(CommandError.authorization),
         );
 
         verify(
           () => logger.severe(
-            'Command ExampleCommand failed with forbidden access error.',
+            'Command ExampleCommand failed with authorization error.',
             any(),
             any(),
           ),
@@ -644,7 +644,7 @@ void main() {
       });
 
       test(
-          'returns OperationFailure(OperationError.forbiddenAccess) when response'
+          'returns OperationFailure(OperationError.authorization) when response'
           ' code is 403 and logs result', () async {
         mockClientPost(client, Response('', 403));
 
@@ -653,13 +653,13 @@ void main() {
         expect(
           result,
           const OperationFailure<bool?>(
-            OperationError.forbiddenAccess,
+            OperationError.authorization,
           ),
         );
 
         verify(
           () => logger.severe(
-            'Operation ExampleOperation failed with forbidden access error.',
+            'Operation ExampleOperation failed with authorization error.',
             any(),
             any(),
           ),

--- a/packages/cqrs/test/cqrs_test.dart
+++ b/packages/cqrs/test/cqrs_test.dart
@@ -2,7 +2,6 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:cqrs/cqrs.dart';
-import 'package:cqrs/src/cqrs_middleware.dart';
 
 import 'package:http/http.dart';
 import 'package:logging/logging.dart';


### PR DESCRIPTION
- Rename `forbiddenAccess` to `authorization` in error enums.
- Update error enums docs.
- Fix `CqrsMiddleware` not being exported from the package.
- Move `hasError` and `hasErrorForProperty` from `CommandResponse` to `CommandFailure`.