### PR TITLE
Bump in force_update cqrs to 10.0.1 and contracts to 0.8.0

### DIFF
--- a/packages/force_update/mobile/CHANGELOG.md
+++ b/packages/force_update/mobile/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.0-alpha
+
+- **Breaking:** bump `cqrs` to `10.0.1` and `leancode_contracts` to `0.8.0`
+
 ## 1.0.0-alpha
 
 Initial release

--- a/packages/force_update/mobile/example/lib/main.dart
+++ b/packages/force_update/mobile/example/lib/main.dart
@@ -20,11 +20,11 @@ void main() async {
   registerFallbackValue(MockQuery());
   when(() => cqrs.get<VersionSupportDTO>(any())).thenAnswer(
     (_) async {
-      return VersionSupportDTO(
+      return QuerySuccess(VersionSupportDTO(
         currentlySupportedVersion: '1.0.0',
         minimumRequiredVersion: '1.2.0',
         result: VersionSupportResultDTO.updateSuggested,
-      );
+      ));
     },
   );
 

--- a/packages/force_update/mobile/lib/src/force_update_guard.dart
+++ b/packages/force_update/mobile/lib/src/force_update_guard.dart
@@ -106,28 +106,28 @@ class _ForceUpdateGuardState extends State<ForceUpdateGuard> {
   Future<void> _updateVersionsInfo() async {
     _logger.info('Looking for updates...');
 
-    try {
-      final platform = switch (defaultTargetPlatform) {
-        TargetPlatform.android => PlatformDTO.android,
-        TargetPlatform.iOS => PlatformDTO.ios,
-        _ => throw StateError('Force update only works for Android & iOS'),
-      };
+    final platform = switch (defaultTargetPlatform) {
+      TargetPlatform.android => PlatformDTO.android,
+      TargetPlatform.iOS => PlatformDTO.ios,
+      _ => throw StateError('Force update only works for Android & iOS'),
+    };
 
-      final response = await widget.cqrs.get(
-        VersionSupport(
-          platform: platform,
-          version: _packageInfo.version,
-        ),
-      );
+    final response = await widget.cqrs.get(
+      VersionSupport(
+        platform: platform,
+        version: _packageInfo.version,
+      ),
+    );
 
+    if (response case QuerySuccess(:final data)) {
       await _storage.writeResult(
         ForceUpdateResult(
           versionAtTimeOfRequest: Version.parse(_packageInfo.version),
-          result: response.result,
+          result: data.result,
         ),
       );
-    } catch (e, st) {
-      _logger.info('Failed to fetch updates info', e, st);
+    } else {
+      _logger.info('Failed to fetch updates info');
     }
   }
 

--- a/packages/force_update/mobile/pubspec.yaml
+++ b/packages/force_update/mobile/pubspec.yaml
@@ -1,5 +1,5 @@
 name: force_update
-version: 1.0.0-alpha
+version: 2.0.0-alpha
 homepage: https://github.com/leancodepl/flutter_corelibrary/tree/master/packages/force_update
 repository: https://github.com/leancodepl/flutter_corelibrary
 description: >-
@@ -10,11 +10,11 @@ environment:
   flutter: ">=3.10.0"
 
 dependencies:
-  cqrs: ^9.0.0
+  cqrs: ^10.0.1
   flutter:
     sdk: flutter
   in_app_update: ^4.1.4
-  leancode_contracts: ^0.6.0
+  leancode_contracts: ^0.8.0
   logging: ^1.2.0 
   package_info_plus: ^4.0.2
   shared_preferences: ^2.2.0

--- a/packages/force_update/mobile/test/utils.dart
+++ b/packages/force_update/mobile/test/utils.dart
@@ -14,7 +14,7 @@ const _suggestUpdateDialogKey = Key('SuggestUpdateKey');
 
 void registerVersionSupportAnswer(Cqrs cqrs, VersionSupportDTO dto) {
   when(() => cqrs.get<VersionSupportDTO>(any())).thenAnswer(
-    (_) async => dto,
+    (_) async => QuerySuccess(dto),
   );
 }
 


### PR DESCRIPTION
Blocked by https://github.com/leancodepl/contractsgenerator-dart/pull/93