### PR TITLE
Add compute implementation from `flutter_svg` that does not spawn isolates in debug mode

### DIFF
--- a/packages/leancode_flutter_svg_adaptive_loader/CHANGELOG.md
+++ b/packages/leancode_flutter_svg_adaptive_loader/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.0
+
+- Fix performance issues in debug mode related to `compute` from `package:flutter`
+
 ## 1.0.0
 
 - Initial release with `FlutterSvgAdaptiveLoader`

--- a/packages/leancode_flutter_svg_adaptive_loader/lib/src/compute.dart
+++ b/packages/leancode_flutter_svg_adaptive_loader/lib/src/compute.dart
@@ -31,10 +31,6 @@ Future<R> _testCompute<Q, R>(
   Q message, {
   String? debugLabel,
 }) {
-  if (foundation.kDebugMode) {
-    final bindingType = foundation.BindingBase.debugBindingType();
-    if (bindingType.toString() == 'AutomatedTestWidgetsFlutterBinding') {}
-  }
   final result = callback(message);
   if (result is Future<R>) {
     return result;

--- a/packages/leancode_flutter_svg_adaptive_loader/lib/src/compute.dart
+++ b/packages/leancode_flutter_svg_adaptive_loader/lib/src/compute.dart
@@ -1,0 +1,49 @@
+/*
+MIT license
+
+Copyright (c) 2018 Dan Field
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+import 'dart:async';
+
+import 'package:flutter/foundation.dart' as foundation;
+
+Future<R> _testCompute<Q, R>(
+  foundation.ComputeCallback<Q, R> callback,
+  Q message, {
+  String? debugLabel,
+}) {
+  if (foundation.kDebugMode) {
+    final bindingType = foundation.BindingBase.debugBindingType();
+    if (bindingType.toString() == 'AutomatedTestWidgetsFlutterBinding') {}
+  }
+  final result = callback(message);
+  if (result is Future<R>) {
+    return result;
+  }
+  return foundation.SynchronousFuture<R>(result);
+}
+
+/// A compute implementation that does not spawn isolates in tests.
+const foundation.ComputeImpl compute =
+    (foundation.kDebugMode || foundation.kIsWeb)
+        ? _testCompute
+        : foundation.compute;

--- a/packages/leancode_flutter_svg_adaptive_loader/lib/src/leancode_flutter_svg_adaptive_loader.dart
+++ b/packages/leancode_flutter_svg_adaptive_loader/lib/src/leancode_flutter_svg_adaptive_loader.dart
@@ -1,10 +1,10 @@
 import 'dart:convert';
 import 'dart:math';
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:leancode_flutter_svg_adaptive_loader/src/compute.dart';
 import 'package:vector_graphics/vector_graphics.dart';
 import 'package:vector_graphics_compiler/vector_graphics_compiler.dart' as vg;
 

--- a/packages/leancode_flutter_svg_adaptive_loader/pubspec.yaml
+++ b/packages/leancode_flutter_svg_adaptive_loader/pubspec.yaml
@@ -1,5 +1,5 @@
 name: leancode_flutter_svg_adaptive_loader
-version: 1.0.0
+version: 1.1.0
 description: Flutter SVG adaptive loader for binary or xml-based formats
 homepage: https://github.com/leancodepl/flutter_corelibrary/tree/master/packages/leancode_flutter_svg_adaptive_loader
 repository: https://github.com/leancodepl/flutter_corelibrary


### PR DESCRIPTION
The fact that `compute` spawns isolates in debug mode caused massive drops in performance related to `.svg` assets loading. When I had a tens of assets in the same view, it took ~5s to load all of them using `FlutterSvgAdaptiveLoader`. That was approx 10x worse than using `SvgAssetLoader` from `flutter_svg`. 

For that reason I brought more optimised `compute` implementation for debug mode from `flutter_svg` package. It seems that this version of `compute` solves performance issues.