### PR TITLE
Create cache key early to avoid resolving DefaultAssetBundle when ancestor is deactivated

### DIFF
--- a/packages/leancode_flutter_svg_adaptive_loader/CHANGELOG.md
+++ b/packages/leancode_flutter_svg_adaptive_loader/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.1.1
 
-- Fix error caused by resolving DefaultAssetBundle
+- Fix error caused by resolving `DefaultAssetBundle` from context
 
 ## 1.1.0
 

--- a/packages/leancode_flutter_svg_adaptive_loader/CHANGELOG.md
+++ b/packages/leancode_flutter_svg_adaptive_loader/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 1.1.0
 
+- Fix error caused by resolving DefaultAssetBundle
+
+## 1.1.0
+
 - Fix performance issues in debug mode related to `compute` from `package:flutter`
 
 ## 1.0.0

--- a/packages/leancode_flutter_svg_adaptive_loader/CHANGELOG.md
+++ b/packages/leancode_flutter_svg_adaptive_loader/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.1.0
+## 1.1.1
 
 - Fix error caused by resolving DefaultAssetBundle
 

--- a/packages/leancode_flutter_svg_adaptive_loader/lib/src/leancode_flutter_svg_adaptive_loader.dart
+++ b/packages/leancode_flutter_svg_adaptive_loader/lib/src/leancode_flutter_svg_adaptive_loader.dart
@@ -57,6 +57,8 @@ class FlutterSvgAdaptiveLoader extends BytesLoader {
   /// loop turns. This is meant to to help tests in particular.
   @override
   Future<ByteData> loadBytes(BuildContext? context) {
+    final key = cacheKey(context);
+
     return _prepareMessage(context).then((message) {
       // Dart encodes strings in UTF-16 so one codepoint is 2 bytes
       final first100Chars = _decode(message, min(200, message.lengthInBytes));
@@ -73,7 +75,7 @@ class FlutterSvgAdaptiveLoader extends BytesLoader {
       } else {
         // Valid UTF-8 encoded string - process as a svg vector
         return svg.cache.putIfAbsent(
-          cacheKey(context),
+          key,
           () => _loadSvg(message),
         );
       }

--- a/packages/leancode_flutter_svg_adaptive_loader/pubspec.yaml
+++ b/packages/leancode_flutter_svg_adaptive_loader/pubspec.yaml
@@ -1,5 +1,5 @@
 name: leancode_flutter_svg_adaptive_loader
-version: 1.1.0+1
+version: 1.1.1
 description: Flutter SVG adaptive loader for binary or xml-based formats
 homepage: https://github.com/leancodepl/flutter_corelibrary/tree/master/packages/leancode_flutter_svg_adaptive_loader
 repository: https://github.com/leancodepl/flutter_corelibrary


### PR DESCRIPTION
Former implementation of `FlutterSvgAdaptiveLoader.loadBytes` causes exception:

```
FlutterError (Looking up a deactivated widget's ancestor is unsafe.
At this point the state of the widget's element tree is no longer stable.
To safely refer to a widget's ancestor in its dispose() method, save a reference to the ancestor by calling dependOnInheritedWidgetOfExactType() in the widget's didChangeDependencies() method.)
```  