### PR TITLE
Make README more appealing to non-LeanCoders

### DIFF
--- a/packages/leancode_lint/CHANGELOG.md
+++ b/packages/leancode_lint/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 7.0.0+1
+
+- Change package description on pub.dev and in README
+
 # 7.0.0
 
 - Implement LeanCode custom lints

--- a/packages/leancode_lint/README.md
+++ b/packages/leancode_lint/README.md
@@ -2,7 +2,7 @@
 
 [![leancode_lint pub.dev badge][pub-badge]][pub-badge-link]
 
-A high-quality, robust, and up-to-date set of lint rules used at LeanCode.
+An opinionated set of high-quality, robust, and up-to-date lint rules used at LeanCode.
 
 ## Installation
 

--- a/packages/leancode_lint/README.md
+++ b/packages/leancode_lint/README.md
@@ -2,7 +2,7 @@
 
 [![leancode_lint pub.dev badge][pub-badge]][pub-badge-link]
 
-Lint rules used internally in LeanCode projects.
+A high-quality, robust, and up-to-date set of lint rules used at LeanCode.
 
 ## Installation
 

--- a/packages/leancode_lint/pubspec.yaml
+++ b/packages/leancode_lint/pubspec.yaml
@@ -2,7 +2,7 @@ name: leancode_lint
 version: 7.0.0
 homepage: https://github.com/leancodepl/flutter_corelibrary/tree/master/packages/leancode_lint
 repository: https://github.com/leancodepl/flutter_corelibrary
-description: Lint rules used at LeanCode.
+description: Robust, high-quality lint rules used at LeanCode.
 
 topics:
   - analysis

--- a/packages/leancode_lint/pubspec.yaml
+++ b/packages/leancode_lint/pubspec.yaml
@@ -1,5 +1,5 @@
 name: leancode_lint
-version: 7.0.0
+version: 7.0.0+1
 homepage: https://github.com/leancodepl/flutter_corelibrary/tree/master/packages/leancode_lint
 repository: https://github.com/leancodepl/flutter_corelibrary
 description: Robust, high-quality lint rules used at LeanCode.


### PR DESCRIPTION
This is just an idea.

I'm a fan of leancode_lint and use it in my personal projects, and open-source ones I maintain(ed) (e.g. [`flutter_downloader`](https://github.com/fluttercommunity/flutter_downloader/blob/e1d96a777ccb394fee0c6e30bc99b12bd8be9456/pubspec.yaml#L28), [`location`](https://github.com/Lyokone/flutterlocation/blob/7cc54d74a5b53f8c6465ca0e4e5171b39fa49f8d/packages/location/pubspec.yaml#L35)). I think the current description is not interesting for outsiders, but it should be. These lint rules are real good.