### PR TITLE
Disable deprecated 3.3.0 lints

### DIFF
--- a/.github/workflows/leancode_lint-publish.yml
+++ b/.github/workflows/leancode_lint-publish.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Dart
         uses: dart-lang/setup-dart@v1
         with:
-          sdk: 3.2
+          sdk: 3.3
 
       - name: Publish and release
         uses: leancodepl/mobile-tools/.github/actions/pub-release@pub-release-v1

--- a/.github/workflows/leancode_lint-test.yml
+++ b/.github/workflows/leancode_lint-test.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - version: 3.16.x
+          - version: 3.19.x
 
     defaults:
       run:

--- a/packages/leancode_lint/CHANGELOG.md
+++ b/packages/leancode_lint/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 9.0.0
+- Disable lints deprecated in Dart 3.3.0
+- Bump minimum Dart version to 3.3
+
 # 8.1.0
 
 - Enable custom lint `avoid_single_child_in_multi_child_widgets` for `Column`, `Row`, `Flex`, `Wrap`, `SliverList`, `MultiSliver`, `SliverChildListDelegate`, `SliverMainAxisGroup`, and `SliverCrossAxisGroup`

--- a/packages/leancode_lint/CHANGELOG.md
+++ b/packages/leancode_lint/CHANGELOG.md
@@ -1,9 +1,6 @@
 # 9.0.0
 - Disable lints deprecated in Dart 3.3.0
 - Bump minimum Dart version to 3.3
-
-# 8.1.0
-
 - Enable custom lint `avoid_single_child_in_multi_child_widgets` for `Column`, `Row`, `Flex`, `Wrap`, `SliverList`, `MultiSliver`, `SliverChildListDelegate`, `SliverMainAxisGroup`, and `SliverCrossAxisGroup`
 - Fix `avoid_conditional_hooks` false positive
 

--- a/packages/leancode_lint/lib/analysis_options.yaml
+++ b/packages/leancode_lint/lib/analysis_options.yaml
@@ -190,7 +190,6 @@ analyzer:
     todo: info
     undone: info
     # hint diagnostic mesages
-    can_be_null_after_null_aware: warning
     deprecated_colon_for_default_value: warning
     deprecated_export_use: info
     deprecated_member_use: info
@@ -208,7 +207,6 @@ linter:
     always_declare_return_types: true
     always_put_control_body_on_new_line: true
     always_put_required_named_parameters_first: false
-    always_require_non_null_named_parameters: false
     always_specify_types: false
     always_use_package_imports: false
     annotate_overrides: true
@@ -238,9 +236,7 @@ linter:
     avoid_relative_lib_imports: true
     avoid_renaming_method_parameters: true
     avoid_return_types_on_setters: true
-    avoid_returning_null_for_future: true
     avoid_returning_null_for_void: true
-    avoid_returning_null: true
     avoid_returning_this: true
     avoid_setters_without_getters: false
     avoid_shadowing_type_parameters: true

--- a/packages/leancode_lint/lib/analysis_options.yaml
+++ b/packages/leancode_lint/lib/analysis_options.yaml
@@ -184,12 +184,12 @@ analyzer:
     use_to_and_as_if_applicable: warning
     valid_regexps: warning
     void_checks: warning
-    # todo disagnostic messages
+    # todo diagnostic messages
     fixme: warning
     hack: ignore
     todo: info
     undone: info
-    # hint diagnostic mesages
+    # hint diagnostic messages
     deprecated_colon_for_default_value: warning
     deprecated_export_use: info
     deprecated_member_use: info

--- a/packages/leancode_lint/lib/lints/constructor_parameters_and_fields_should_have_the_same_order.dart
+++ b/packages/leancode_lint/lib/lints/constructor_parameters_and_fields_should_have_the_same_order.dart
@@ -13,7 +13,7 @@ class ConstructorParametersAndFieldsShouldHaveTheSameOrder
   static const ruleName =
       'constructor_parameters_and_fields_should_have_the_same_order';
 
-  // TOOD: disabled until stabilized. Add documentation.
+  // TODO: disabled until stabilized. Add documentation.
   @override
   bool get enabledByDefault => false;
 

--- a/packages/leancode_lint/pubspec.yaml
+++ b/packages/leancode_lint/pubspec.yaml
@@ -9,7 +9,7 @@ topics:
   - lints
 
 environment:
-  sdk: ">=3.2.0 <4.0.0"
+  sdk: ">=3.3.0 <4.0.0"
 
 dependencies:
   analyzer: ^6.1.0


### PR DESCRIPTION
Disables a few lints that were deprecated or removed for the 3.3.0 Dart release. Also bumps the SDK to that version.