### PR TITLE
Add linter rule to disallow string literals in `Widget` classes

### DIFF
--- a/packages/leancode_lint/lib/leancode_lint.dart
+++ b/packages/leancode_lint/lib/leancode_lint.dart
@@ -5,6 +5,7 @@ import 'package:leancode_lint/assists/convert_record_into_nominal_type.dart';
 import 'package:leancode_lint/lints/add_cubit_suffix_for_cubits.dart';
 import 'package:leancode_lint/lints/avoid_conditional_hooks.dart';
 import 'package:leancode_lint/lints/avoid_single_child_in_multi_child_widget.dart';
+import 'package:leancode_lint/lints/avoid_string_literals_in_widgets.dart';
 import 'package:leancode_lint/lints/catch_parameter_names.dart';
 import 'package:leancode_lint/lints/constructor_parameters_and_fields_should_have_the_same_order.dart';
 import 'package:leancode_lint/lints/hook_widget_does_not_use_hooks.dart';
@@ -26,6 +27,7 @@ class _Linter extends PluginBase {
         HookWidgetDoesNotUseHooks(),
         ConstructorParametersAndFieldsShouldHaveTheSameOrder(),
         AvoidSingleChildInMultiChildWidgets(),
+        AvoidStringLiteralsInWidgets(),
       ];
 
   @override

--- a/packages/leancode_lint/lib/lints/avoid_string_literals_in_widgets.dart
+++ b/packages/leancode_lint/lib/lints/avoid_string_literals_in_widgets.dart
@@ -1,0 +1,53 @@
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/error/error.dart';
+import 'package:analyzer/error/listener.dart';
+import 'package:custom_lint_builder/custom_lint_builder.dart';
+import 'package:leancode_lint/helpers.dart';
+
+/// Displays warning for cubits which do not have the `Cubit` suffix in their
+/// class name.
+class AvoidStringLiteralsInWidgets extends DartLintRule {
+  AvoidStringLiteralsInWidgets() : super(code: _getLintCode());
+
+  static const ruleName = 'avoid_string_literals_in_widgets';
+
+  @override
+  void run(
+    CustomLintResolver resolver,
+    ErrorReporter reporter,
+    CustomLintContext context,
+  ) {
+    context.registry.addClassDeclaration(
+      (node) {
+        final isThisWidgetClass = isWidgetClass(node);
+        if (!isThisWidgetClass) {
+          return;
+        }
+
+        final buildMethod = getBuildMethod(node);
+        if (buildMethod == null) {
+          return;
+        }
+
+        final stringLiterals = _getDescendantStringLiterals(node);
+
+        for (final stringLiteral in stringLiterals) {
+          reporter.reportErrorForNode(_getLintCode(), stringLiteral);
+        }
+      },
+    );
+  }
+
+  static List<AstNode> _getDescendantStringLiterals(node) {
+    return [];
+  }
+
+  static LintCode _getLintCode() {
+    return const LintCode(
+      name: ruleName,
+      problemMessage: 'Do not use string literals in widgets.',
+      correctionMessage: 'Prefer a localized message.',
+      errorSeverity: ErrorSeverity.WARNING,
+    );
+  }
+}

--- a/packages/leancode_lint/test/lints_test_app/lib/avoid_conditional_hooks_test.dart
+++ b/packages/leancode_lint/test/lints_test_app/lib/avoid_conditional_hooks_test.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: avoid_string_literals_in_widgets
+
 import 'dart:math';
 
 import 'package:flutter/material.dart';

--- a/packages/leancode_lint/test/lints_test_app/lib/avoid_string_literals_in_widgets_test.dart
+++ b/packages/leancode_lint/test/lints_test_app/lib/avoid_string_literals_in_widgets_test.dart
@@ -1,0 +1,47 @@
+// ignore_for_file: avoid_print
+
+import 'package:flutter/material.dart';
+
+class MyStatelessWidget extends StatelessWidget {
+  const MyStatelessWidget({super.key});
+
+  // expect_lint: avoid_string_literals_in_widgets
+  final aStringVariable = 'This is an hardcoded text';
+
+  // expect_lint: avoid_string_literals_in_widgets
+  final anInterpolatedStringVariable = 'This is a number: ${1}';
+
+  @override
+  Widget build(BuildContext context) {
+    try {
+      // expect_lint: avoid_string_literals_in_widgets
+      print('Executing something...');
+      _doSomethingBad();
+    } catch (err) {
+      print('Something bad happened.');
+    }
+
+    return Column(
+      children: [
+        // expect_lint: avoid_string_literals_in_widgets
+        const WidgetWithText('This is an hardcoded text'),
+        WidgetWithText(aStringVariable),
+      ],
+    );
+  }
+
+  void _doSomethingBad() {
+    throw Exception('Bad stuff happening');
+  }
+}
+
+class WidgetWithText extends StatelessWidget {
+  const WidgetWithText(this.text, {super.key});
+
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container();
+  }
+}

--- a/packages/leancode_lint/test/lints_test_app/lib/hook_widget_does_not_use_hooks_test.dart
+++ b/packages/leancode_lint/test/lints_test_app/lib/hook_widget_does_not_use_hooks_test.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: avoid_string_literals_in_widgets
+
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';

--- a/packages/leancode_lint/test/lints_test_app/lib/use_design_system_item_test.dart
+++ b/packages/leancode_lint/test/lints_test_app/lib/use_design_system_item_test.dart
@@ -1,4 +1,5 @@
 // ignore_for_file: unused_local_variable
+// ignore_for_file: avoid_string_literals_in_widgets
 
 import 'package:flutter/material.dart';
 


### PR DESCRIPTION
Closes #260 
This linter rule makes code review easier for internationalized apps, by preventing the usage of string literals in widgets.

This may be annoying, since we need string literals for things other than UI inside a widget's class, and it's not possible (at least from what I've seen from the analyzer API) to guarantee with a 100% certainty that they are being used in that context. As such, I added 2 simple exceptions:
- When handling an exception: so that we can log it/send to a server
- When throwing an exception: so that we can define a proper message

Furthermore, there are some things we should discuss:
- Should we make these ancestor exceptions configurable?
- Should the exceptions be related instead to e.g. the number of the function that is being invoked?