### PR TITLE
Remove legacy lints

### DIFF
--- a/packages/leancode_lint/CHANGELOG.md
+++ b/packages/leancode_lint/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 12.0.0
+
+- Remove deprecated `import_of_legacy_library_into_null_safe` error code
+
 # 11.0.0
 
 - Treat `HookConsumer` and `HookConsumerWidget` from `package:hooks_riverpod` as hook widgets

--- a/packages/leancode_lint/README.md
+++ b/packages/leancode_lint/README.md
@@ -8,9 +8,9 @@ An opinionated set of high-quality, robust, and up-to-date lint rules used at Le
 
 1. Add `leancode_lint` and `custom_lint` as a dev dependency in your project's `pubspec.yaml`.
 
-```sh
-dart pub add leancode_lint custom_lint --dev
-```
+   ```sh
+   dart pub add leancode_lint custom_lint --dev
+   ```
 
 2. In your `analysis_options.yaml` add `include: package:leancode_lint/analysis_options.yaml`. You might want to exclude some files
    (e.g generated json serializable) from analysis.

--- a/packages/leancode_lint/lib/analysis_options.yaml
+++ b/packages/leancode_lint/lib/analysis_options.yaml
@@ -195,7 +195,6 @@ analyzer:
     deprecated_member_use: info
     division_optimization: warning
     import_deferred_library_with_load_function: warning
-    import_of_legacy_library_into_null_safe: warning
     unignorable_ignore: warning
     unnecessary_cast: warning
     unnecessary_import: warning

--- a/packages/leancode_lint/pubspec.yaml
+++ b/packages/leancode_lint/pubspec.yaml
@@ -1,5 +1,5 @@
 name: leancode_lint
-version: 11.0.0
+version: 12.0.0
 homepage: https://github.com/leancodepl/flutter_corelibrary/tree/master/packages/leancode_lint
 repository: https://github.com/leancodepl/flutter_corelibrary
 description: Robust, high-quality lint rules used at LeanCode.

--- a/packages/leancode_lint/pubspec.yaml
+++ b/packages/leancode_lint/pubspec.yaml
@@ -12,6 +12,6 @@ environment:
   sdk: ">=3.3.0 <4.0.0"
 
 dependencies:
-  analyzer: ^6.1.0
-  analyzer_plugin: ^0.11.2
-  custom_lint_builder: ^0.6.2
+  analyzer: ^6.4.1
+  analyzer_plugin: ^0.11.3
+  custom_lint_builder: ^0.6.4

--- a/packages/leancode_lint/test/lints_test_app/pubspec.lock
+++ b/packages/leancode_lint/test/lints_test_app/pubspec.lock
@@ -117,26 +117,26 @@ packages:
     dependency: "direct dev"
     description:
       name: custom_lint
-      sha256: "445242371d91d2e24bd7b82e3583a2c05610094ba2d0575262484ad889c8f981"
+      sha256: "7c0aec12df22f9082146c354692056677f1e70bc43471644d1fdb36c6fdda799"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.2"
+    version: "0.6.4"
   custom_lint_builder:
     dependency: transitive
     description:
       name: custom_lint_builder
-      sha256: "4c0aed2a3491096e91cf1281923ba1b6814993f16dde0fd60f697925225bbbd6"
+      sha256: d7dc41e709dde223806660268678be7993559e523eb3164e2a1425fd6f7615a9
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.2"
+    version: "0.6.4"
   custom_lint_core:
     dependency: transitive
     description:
       name: custom_lint_core
-      sha256: ce5d6215f4e143f7780ce53f73dfa6fc503f39d2d30bef76c48be9ac1a09d9a6
+      sha256: a85e8f78f4c52f6c63cdaf8c872eb573db0231dcdf3c3a5906d493c1f8bc20e6
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.2"
+    version: "0.6.3"
   dart_style:
     dependency: transitive
     description:
@@ -170,10 +170,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_bloc
-      sha256: "87325da1ac757fcc4813e6b34ed5dd61169973871fdf181d6c2109dd6935ece1"
+      sha256: f0ecf6e6eb955193ca60af2d5ca39565a86b8a142452c5b24d96fb477428f4d2
       url: "https://pub.dev"
     source: hosted
-    version: "8.1.4"
+    version: "8.1.5"
   flutter_hooks:
     dependency: "direct main"
     description:
@@ -186,10 +186,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_riverpod
-      sha256: "4bce556b7ecbfea26109638d5237684538d4abc509d253e6c5c4c5733b360098"
+      sha256: "0f1974eff5bbe774bf1d870e406fc6f29e3d6f1c46bd9c58e7172ff68a785d7d"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.10"
+    version: "2.5.1"
   freezed_annotation:
     dependency: transitive
     description:
@@ -210,10 +210,10 @@ packages:
     dependency: "direct main"
     description:
       name: hooks_riverpod
-      sha256: "758b07eba336e3cbacbd81dba481f2228a14102083fdde07045e8514e8054c49"
+      sha256: "45b2030a18bcd6dbd680c2c91bc3b33e3fe7c323e3acb5ecec93a613e2fbaa8a"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.10"
+    version: "2.5.1"
   hotreloader:
     dependency: transitive
     description:
@@ -236,7 +236,7 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "10.0.0"
+    version: "11.0.0"
   logging:
     dependency: transitive
     description:
@@ -257,18 +257,18 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
+      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.12.0"
   nested:
     dependency: transitive
     description:
@@ -321,10 +321,10 @@ packages:
     dependency: transitive
     description:
       name: riverpod
-      sha256: "548e2192eb7aeb826eb89387f814edb76594f3363e2c0bb99dd733d795ba3589"
+      sha256: f21b32ffd26a36555e501b04f4a5dca43ed59e16343f1a30c13632b2351dfa4d
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.0"
+    version: "2.5.1"
   rxdart:
     dependency: transitive
     description:

--- a/packages/leancode_lint/test/lints_test_app/pubspec.yaml
+++ b/packages/leancode_lint/test/lints_test_app/pubspec.yaml
@@ -11,13 +11,13 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_bloc: ^8.0.1
-  flutter_hooks: ^0.20.2
-  hooks_riverpod: ^2.4.10
+  flutter_bloc: ^8.1.5
+  flutter_hooks: ^0.20.5
+  hooks_riverpod: ^2.5.1
   sliver_tools: ^0.2.12
 
 dev_dependencies:
-  custom_lint: ^0.6.2
+  custom_lint: ^0.6.4
   leancode_lint:
     path: ../../../leancode_lint
 


### PR DESCRIPTION
Removes the reference to `import_of_legacy_library_into_null_safe` (Will have been removed in Dart 3.4.0 via https://github.com/dart-lang/sdk/commit/14a9782895762056dc0d705bf0253817bb2ac37c, but it was already deprecated)