### PR TITLE
Fix custom lint: comparing constructor parameters' order with fields

### DIFF
--- a/packages/leancode_lint/lib/lints/constructor_parameters_and_fields_should_have_the_same_order.dart
+++ b/packages/leancode_lint/lib/lints/constructor_parameters_and_fields_should_have_the_same_order.dart
@@ -54,21 +54,19 @@ class ConstructorParametersAndFieldsShouldHaveTheSameOrder
     ConstructorDeclaration constructor,
     List<FieldDeclaration> fields,
   ) {
-    final parameters =
-        constructor.parameters.parameters.where((p) => !p.isExplicitlyTyped);
+    final parameters = constructor.parameters.parameters.where(
+      (parameter) =>
+          !parameter.isExplicitlyTyped && _isNotSuperFormal(parameter),
+    );
     if (parameters.isEmpty) {
       return true;
     }
 
-    final namedParameters = parameters
-        .where((parameter) => parameter.isNamed && _isNotSuperFormal(parameter))
-        .toList();
+    final namedParameters =
+        parameters.where((parameter) => parameter.isNamed).toList();
 
-    final unnamedParameters = parameters
-        .where(
-          (parameter) => !parameter.isNamed && _isNotSuperFormal(parameter),
-        )
-        .toList();
+    final unnamedParameters =
+        parameters.where((parameter) => !parameter.isNamed).toList();
 
     final fieldsWithNamedParameters = fields
         .where(

--- a/packages/leancode_lint/lib/lints/constructor_parameters_and_fields_should_have_the_same_order.dart
+++ b/packages/leancode_lint/lib/lints/constructor_parameters_and_fields_should_have_the_same_order.dart
@@ -54,7 +54,8 @@ class ConstructorParametersAndFieldsShouldHaveTheSameOrder
     ConstructorDeclaration constructor,
     List<FieldDeclaration> fields,
   ) {
-    final parameters = constructor.parameters.parameters;
+    final parameters =
+        constructor.parameters.parameters.where((p) => !p.isExplicitlyTyped);
     if (parameters.isEmpty) {
       return true;
     }


### PR DESCRIPTION
Fixes `constructor_parameters_and_fields_should_have_the_same_order` custom lint.

It reported warnings for parameters, that had explicit types in constructors (so they didn't have corresponding fields) and were above parameters that had corresponding fields.

Example that triggers an error:

```
class MyClass{
    MyClass(String text, this.field){
        _init(text);
    }

    final TextField field;
}
```

Example without error:

```
class MyClass{
    MyClass(this.field, String text){
        _init(text);
    }

    final TextField field;
}
```

The parameters that should be taken to comparison with fields are the ones without explicit types.