### PR TITLE
Change diagnostic location for `constructor_parameters_and_fields_should_have_the_same_order`

### DIFF
--- a/packages/leancode_lint/lib/lints/constructor_parameters_and_fields_should_have_the_same_order.dart
+++ b/packages/leancode_lint/lib/lints/constructor_parameters_and_fields_should_have_the_same_order.dart
@@ -34,15 +34,9 @@ class ConstructorParametersAndFieldsShouldHaveTheSameOrder
         final constructors = node.members.whereType<ConstructorDeclaration>();
         for (final constructor in constructors) {
           if (!_hasValidOrder(constructor, fields)) {
-            final firstParameter = constructor.parameters.parameters.first;
-            final lastParameter = constructor.parameters.parameters.last;
-
-            reporter.reportErrorForOffset(
+            reporter.reportErrorForNode(
               _getLintCode(),
-              firstParameter.offset,
-              lastParameter.offset +
-                  lastParameter.length -
-                  firstParameter.offset,
+              constructor,
             );
           }
         }

--- a/packages/leancode_lint/lib/lints/constructor_parameters_and_fields_should_have_the_same_order.dart
+++ b/packages/leancode_lint/lib/lints/constructor_parameters_and_fields_should_have_the_same_order.dart
@@ -34,10 +34,7 @@ class ConstructorParametersAndFieldsShouldHaveTheSameOrder
         final constructors = node.members.whereType<ConstructorDeclaration>();
         for (final constructor in constructors) {
           if (!_hasValidOrder(constructor, fields)) {
-            reporter.reportErrorForNode(
-              _getLintCode(),
-              constructor,
-            );
+            reporter.reportErrorForNode(_getLintCode(), constructor);
           }
         }
       },

--- a/packages/leancode_lint/test/lints_test_app/lib/constructor_parameters_and_fields_should_have_the_same_order_test.dart
+++ b/packages/leancode_lint/test/lints_test_app/lib/constructor_parameters_and_fields_should_have_the_same_order_test.dart
@@ -1,6 +1,6 @@
 class ClassWithInvalidUnnamedParametersOrder {
+  // expect_lint: constructor_parameters_and_fields_should_have_the_same_order
   const ClassWithInvalidUnnamedParametersOrder(
-    // expect_lint: constructor_parameters_and_fields_should_have_the_same_order
     this.third,
     this.second,
     this.first,
@@ -8,8 +8,8 @@ class ClassWithInvalidUnnamedParametersOrder {
     this.fifth,
   );
 
+  // expect_lint: constructor_parameters_and_fields_should_have_the_same_order
   const ClassWithInvalidUnnamedParametersOrder.anotherConstructor(
-    // expect_lint: constructor_parameters_and_fields_should_have_the_same_order
     this.third,
     this.second,
     this.first,
@@ -25,8 +25,8 @@ class ClassWithInvalidUnnamedParametersOrder {
 }
 
 class ClassWithInvalidNamedParametersOrder {
+  // expect_lint: constructor_parameters_and_fields_should_have_the_same_order
   const ClassWithInvalidNamedParametersOrder({
-    // expect_lint: constructor_parameters_and_fields_should_have_the_same_order
     required this.third,
     required this.first,
     required this.fourth,
@@ -90,8 +90,8 @@ class ClassWithValidNamedParametersOrder {
 }
 
 class ClassWithInvalidNamedParametersOrderAndWithNonThisParameter {
+  // expect_lint: constructor_parameters_and_fields_should_have_the_same_order
   const ClassWithInvalidNamedParametersOrderAndWithNonThisParameter({
-    // expect_lint: constructor_parameters_and_fields_should_have_the_same_order
     required this.first,
     required this.second,
     required String otherParameter,
@@ -131,8 +131,8 @@ class ClassWithValidNamedParametersOrderAndWithNonThisParameter {
 }
 
 class ClassWithInvalidUnnamedParametersOrderAndWithNonThisParameter {
+  // expect_lint: constructor_parameters_and_fields_should_have_the_same_order
   const ClassWithInvalidUnnamedParametersOrderAndWithNonThisParameter(
-    // expect_lint: constructor_parameters_and_fields_should_have_the_same_order
     this.third,
     this.second,
     String otherParameter,
@@ -217,8 +217,8 @@ class ClassWithMixedParametersWithValidOrder extends _AbstractClassWithField {
 }
 
 class ClassWithMixedParametersWithInvalidOrder extends _AbstractClassWithField {
+  // expect_lint: constructor_parameters_and_fields_should_have_the_same_order
   const ClassWithMixedParametersWithInvalidOrder(
-    // expect_lint: constructor_parameters_and_fields_should_have_the_same_order
     super.a,
     this.second,
     this.first, {


### PR DESCRIPTION
Changes how `constructor_parameters_and_fields_should_have_the_same_order` reports issues.

Right now the issue is reported just above the first parameter, which doesn't always cause the problem. In my opinion it would be better if the lint reported issues above the constructor.
This is especially confusing when one wants to use `ignore`:

How it looks now:
```
class MyClass{
    MyClass({
        // ignore: constructor_parameters_and_fields_should_have_the_same_order
        required this.value,
        required this.label,
        required this.enabled,
    });

    final bool enabled;
    final double value;
    final String label;
}
```

How it looks after my changes:
```
class MyClass{
    // ignore: constructor_parameters_and_fields_should_have_the_same_order
    MyClass({
        required this.value,
        required this.label,
        required this.enabled,
    });

    final bool enabled;
    final double value;
    final String label;
}
```