### PR TITLE
Always set `tokenEndpoint` using value of `authorizationUri` from `OAuthSettings` during `LoginClient` initialization.

### DIFF
--- a/packages/login_client/CHANGELOG.md
+++ b/packages/login_client/CHANGELOG.md
@@ -1,5 +1,6 @@
-# Unreleased
+# 3.2.0
 
+- Add option to override `tokenEndpoint` from saved `Credentials` during initialization.
 - Bump `leancode_lint` dev dependency to `12.0.0`.
 - Bump `custom_lint` dev dependency to `0.6.4`.
 

--- a/packages/login_client/CHANGELOG.md
+++ b/packages/login_client/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 3.2.0
 
-- Add option to override `tokenEndpoint` from saved `Credentials` during initialization.
+- Always set `tokenEndpoint` using value of `authorizationUri` from `OAuthSettings` during `LoginClient` initialization.
 - Bump `leancode_lint` dev dependency to `12.0.0`.
 - Bump `custom_lint` dev dependency to `0.6.4`.
 

--- a/packages/login_client/CHANGELOG.md
+++ b/packages/login_client/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 3.2.0
 
-- Always set `tokenEndpoint` using value of `authorizationUri` from `OAuthSettings` during `LoginClient` initialization.
+- Always use `OAuthSettings.authorizationUri` for token endpoint in `LoginClient` initialization (for refreshing the token).
 - Bump `leancode_lint` dev dependency to `12.0.0`.
 - Bump `custom_lint` dev dependency to `0.6.4`.
 

--- a/packages/login_client/lib/src/login_client.dart
+++ b/packages/login_client/lib/src/login_client.dart
@@ -107,8 +107,8 @@ class LoginClient extends http.BaseClient {
     }
   }
 
-  /// Restores saved credentials from the credentials storage and set
-  /// `tokenEndpoint`to the one provided in the `oAuthSettings`.
+  /// Restores saved credentials from the credentials storage and sets
+  /// `tokenEndpoint` to the one provided in the `oAuthSettings`.
   Future<Credentials?> get _credentialsToInitialize async {
     final credentials = await _credentialsStorage.read();
 

--- a/packages/login_client/lib/src/login_client.dart
+++ b/packages/login_client/lib/src/login_client.dart
@@ -84,10 +84,9 @@ class LoginClient extends http.BaseClient {
 
   /// Restores saved credentials from the credentials storage.
   ///
-  /// You can provide a custom `tokenEndpoint` to override the one stored in
-  /// the credentials. This is useful when the token endpoint changes.
+  /// `_oAuthSettings.authorizationUri` is used as the `tokenEndpoint`.
   Future<void> initialize() async {
-    final credentials = await _credentialsToInitialize;
+    final credentials = await getCredentialsToInitialize();
 
     if (credentials != null) {
       _oAuthClient = buildOAuth2ClientFromCredentials(
@@ -109,7 +108,7 @@ class LoginClient extends http.BaseClient {
 
   /// Restores saved credentials from the credentials storage and sets
   /// `tokenEndpoint` to the one provided in the `oAuthSettings`.
-  Future<Credentials?> get _credentialsToInitialize async {
+  Future<Credentials?> getCredentialsToInitialize() async {
     final credentials = await _credentialsStorage.read();
 
     if (credentials != null) {

--- a/packages/login_client/lib/src/login_client.dart
+++ b/packages/login_client/lib/src/login_client.dart
@@ -87,20 +87,10 @@ class LoginClient extends http.BaseClient {
   /// You can provide a custom `tokenEndpoint` to override the one stored in
   /// the credentials. This is useful when the token endpoint changes.
   Future<void> initialize({Uri? tokenEndpoint}) async {
-    var credentials = await _credentialsStorage.read();
+    final credentials =
+        await _getCredentialsToInitialize(tokenEndpoint: tokenEndpoint);
 
     if (credentials != null) {
-      if (tokenEndpoint != null) {
-        credentials = Credentials(
-          credentials.accessToken,
-          refreshToken: credentials.refreshToken,
-          idToken: credentials.idToken,
-          tokenEndpoint: tokenEndpoint,
-          scopes: credentials.scopes,
-          expiration: credentials.expiration,
-        );
-      }
-
       _oAuthClient = buildOAuth2ClientFromCredentials(
         credentials,
         oAuthSettings: _oAuthSettings,
@@ -116,6 +106,27 @@ class LoginClient extends http.BaseClient {
     } else {
       _logger('Successfully initialized with no credentials.');
     }
+  }
+
+  Future<Credentials?> _getCredentialsToInitialize({Uri? tokenEndpoint}) async {
+    final credentials = await _credentialsStorage.read();
+
+    if (credentials != null) {
+      if (tokenEndpoint != null) {
+        return Credentials(
+          credentials.accessToken,
+          refreshToken: credentials.refreshToken,
+          idToken: credentials.idToken,
+          tokenEndpoint: tokenEndpoint,
+          scopes: credentials.scopes,
+          expiration: credentials.expiration,
+        );
+      }
+
+      return credentials;
+    }
+
+    return null;
   }
 
   /// Authorizes the [LoginClient] using the passed `strategy`.

--- a/packages/login_client/lib/src/login_client.dart
+++ b/packages/login_client/lib/src/login_client.dart
@@ -15,6 +15,7 @@
 import 'dart:async';
 
 import 'package:http/http.dart' as http;
+import 'package:login_client/login_client.dart';
 import 'package:meta/meta.dart';
 import 'package:oauth2/oauth2.dart' as oauth2;
 
@@ -87,9 +88,21 @@ class LoginClient extends http.BaseClient {
   Future<oauth2.Credentials?> get credentials => _credentialsStorage.read();
 
   /// Restores saved credentials from the credentials storage.
-  Future<void> initialize() async {
-    final credentials = await _credentialsStorage.read();
+  Future<void> initialize({Uri? tokenEndpoint}) async {
+    var credentials = await _credentialsStorage.read();
+
     if (credentials != null) {
+      if (tokenEndpoint != null) {
+        credentials = Credentials(
+          credentials.accessToken,
+          refreshToken: credentials.refreshToken,
+          idToken: credentials.idToken,
+          tokenEndpoint: tokenEndpoint,
+          scopes: credentials.scopes,
+          expiration: credentials.expiration,
+        );
+      }
+
       _oAuthClient = buildOAuth2ClientFromCredentials(
         credentials,
         oAuthSettings: _oAuthSettings,

--- a/packages/login_client/lib/src/login_client.dart
+++ b/packages/login_client/lib/src/login_client.dart
@@ -83,6 +83,9 @@ class LoginClient extends http.BaseClient {
   Future<oauth2.Credentials?> get credentials => _credentialsStorage.read();
 
   /// Restores saved credentials from the credentials storage.
+  ///
+  /// You can provide a custom `tokenEndpoint` to override the one stored in
+  /// the credentials. This is useful when the token endpoint changes.
   Future<void> initialize({Uri? tokenEndpoint}) async {
     var credentials = await _credentialsStorage.read();
 

--- a/packages/login_client/lib/src/login_client.dart
+++ b/packages/login_client/lib/src/login_client.dart
@@ -19,11 +19,6 @@ import 'package:login_client/login_client.dart';
 import 'package:meta/meta.dart';
 import 'package:oauth2/oauth2.dart' as oauth2;
 
-import 'credentials_storage/credentials_storage.dart';
-import 'credentials_storage/in_memory_credentials_storage.dart';
-import 'oauth_settings.dart';
-import 'refresh_exception.dart';
-import 'strategies/authorization_strategy.dart';
 import 'utils.dart';
 
 typedef _LoggerCallback = void Function(String);

--- a/packages/login_client/lib/src/utils.dart
+++ b/packages/login_client/lib/src/utils.dart
@@ -14,6 +14,7 @@
 
 import 'package:http/http.dart' as http;
 import 'package:oauth2/oauth2.dart' as oauth2;
+import 'package:oauth2/oauth2.dart';
 
 import 'oauth_settings.dart';
 
@@ -34,4 +35,19 @@ oauth2.Client buildOAuth2ClientFromCredentials(
     httpClient: httpClient,
     onCredentialsRefreshed: onCredentialsRefreshed,
   );
+}
+
+/// Extension methods for the [Credentials] class.
+extension CredentialsExt on Credentials {
+  /// Creates a copy of the current [Credentials] with the provided [tokenEndpoint].
+  Credentials copyWithTokenEndpoint(Uri newTokenEndpoint) {
+    return Credentials(
+      accessToken,
+      refreshToken: refreshToken,
+      idToken: idToken,
+      tokenEndpoint: newTokenEndpoint,
+      scopes: scopes,
+      expiration: expiration,
+    );
+  }
 }

--- a/packages/login_client/pubspec.yaml
+++ b/packages/login_client/pubspec.yaml
@@ -1,5 +1,5 @@
 name: login_client
-version: 3.1.0
+version: 3.2.0
 homepage: https://github.com/leancodepl/flutter_corelibrary/tree/master/packages/login_client
 repository: https://github.com/leancodepl/flutter_corelibrary
 description: >-

--- a/packages/login_client/test/login_client_test.dart
+++ b/packages/login_client/test/login_client_test.dart
@@ -94,10 +94,9 @@ void main() {
           expectAsync1((credentials) {
             expect(
               credentials?.toJson(),
-              Credentials(
-                'some token',
-                tokenEndpoint: Uri.parse('https://leancode.co'),
-              ).toJson(),
+              credentials
+                  ?.copyWithTokenEndpoint(Uri.parse('https://leancode.co'))
+                  .toJson(),
             );
           }),
         );

--- a/packages/login_client/test/login_client_test.dart
+++ b/packages/login_client/test/login_client_test.dart
@@ -93,10 +93,8 @@ void main() {
         loginClient.onCredentialsChanged.listen(
           expectAsync1((credentials) {
             expect(
-              credentials?.toJson(),
-              credentials
-                  ?.copyWithTokenEndpoint(Uri.parse('https://leancode.co'))
-                  .toJson(),
+              credentials?.tokenEndpoint,
+              Uri.parse('https://leancode.co'),
             );
           }),
         );


### PR DESCRIPTION
fix #334 