### PR TITLE
Update CHANGELOG.md

### DIFF
--- a/packages/leancode_lint/CHANGELOG.md
+++ b/packages/leancode_lint/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 # 14.0.0
 
+- Bump minimum Dart version to 3.5
 - Enable the following lints:
   - [`unintended_html_in_doc_comment`](https://dart.dev/lints/unintended_html_in_doc_comment)
   - [`invalid_runtime_check_with_js_interop_types`](https://dart.dev/lints/invalid_runtime_check_with_js_interop_types)


### PR DESCRIPTION
It able to use leancode_lint: 14.0.0 with Dart SDK 3.4.4. So the changelog file should mention this limitation.

```
[my-app] flutter pub get --no-example
Resolving dependencies...
The current Dart SDK version is 3.4.4.

Because my_ app depends on leancode_lint >=14.0.0 which requires SDK version >=3.5.0 <4.0.0, version solving failed.

You can try the following suggestion to make the pubspec resolve:
* Consider downgrading your constraint on leancode_lint: flutter pub add dev:leancode_lint:^13.0.0
exit code 1
```