### PR TITLE
Normalize keys in hooks

### DIFF
--- a/packages/leancode_hooks/CHANGELOG.md
+++ b/packages/leancode_hooks/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- **Breaking**: Replace all `keys` that were declared as [optional positional parameter](https://dart.dev/language/functions#optional-positional-parameters) with a [named parameter](https://dart.dev/language/functions#named-parameters) that defaults to `const List<Object?>[]`. Affected hooks: `useBloc`, `usePostFrameEffect`, `useTapGestureRecognizer`.
 - Bump `leancode_lint` dev dependency to `12.0.0`.
 - Bump `custom_lint` dev dependency to `0.6.4`.
 

--- a/packages/leancode_hooks/lib/src/use_bloc.dart
+++ b/packages/leancode_hooks/lib/src/use_bloc.dart
@@ -4,9 +4,9 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 /// Provides a [Cubit] or a [Bloc] that is automatically disposed without having
 /// to use BlocProvider.
 B useBloc<B extends BlocBase<Object?>>(
-  B Function() create, [
+  B Function() create, {
   List<Object?> keys = const [],
-]) {
+}) {
   final bloc = useMemoized(create, keys);
 
   useEffect(() => bloc.close, [bloc]);

--- a/packages/leancode_hooks/lib/src/use_post_frame_effect.dart
+++ b/packages/leancode_hooks/lib/src/use_post_frame_effect.dart
@@ -2,8 +2,11 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 
 /// Registers [effect] to be run in
-/// WidgetsBinding.instance.addPostFrameCallback.
-void usePostFrameEffect(VoidCallback effect, [List<Object?>? keys]) {
+/// [WidgetsBinding.instance.addPostFrameCallback].
+void usePostFrameEffect(
+  VoidCallback effect, {
+  List<Object?> keys = const [],
+}) {
   useEffect(
     () {
       WidgetsBinding.instance.addPostFrameCallback((_) => effect());

--- a/packages/leancode_hooks/lib/src/use_stream_listener.dart
+++ b/packages/leancode_hooks/lib/src/use_stream_listener.dart
@@ -11,7 +11,7 @@ void useStreamListener<T>(
   Stream<T> stream,
   ValueChanged<T> onData, {
   Function? onError,
-  void Function()? onDone,
+  VoidCallback? onDone,
   bool? cancelOnError,
   List<Object?> keys = const [],
 }) {

--- a/packages/leancode_hooks/lib/src/use_tap_gesture_recognizer.dart
+++ b/packages/leancode_hooks/lib/src/use_tap_gesture_recognizer.dart
@@ -5,9 +5,9 @@ export 'package:flutter/gestures.dart' show TapGestureRecognizer;
 
 /// Creates a [TapGestureRecognizer] that will be disposed automatically.
 TapGestureRecognizer useTapGestureRecognizer(
-  TapGestureRecognizer Function() builder, [
+  TapGestureRecognizer Function() builder, {
   List<Object?> keys = const [],
-]) {
+}) {
   final tapGestureRecognizer = useMemoized(builder, keys);
 
   useEffect(() => tapGestureRecognizer.dispose, [tapGestureRecognizer]);

--- a/packages/leancode_hooks/pubspec.yaml
+++ b/packages/leancode_hooks/pubspec.yaml
@@ -6,8 +6,8 @@ description: >-
   Hooks we often use, all gathered in one place.
 
 environment:
-  sdk: '>=3.0.0 <4.0.0'
-  flutter: '>=3.10.0 <4.0.0'
+  sdk: ">=3.0.0 <4.0.0"
+  flutter: ">=3.10.0 <4.0.0"
 
 dependencies:
   bloc: ^8.0.3


### PR DESCRIPTION
Currently, our hooks use `keys` inconsistently - some keys are declared as `List<Object?>`, while some are declared as `List<Object?>?`. Moreover, some keys are declared as an optional positional parameter, while others are a named parameter with a default value.

This PR turns all `keys` into a named parameter with a default value (`List<Object?> keys = const []`).