### PR TITLE
Add useDisposable hook

### DIFF
--- a/packages/leancode_hooks/CHANGELOG.md
+++ b/packages/leancode_hooks/CHANGELOG.md
@@ -1,5 +1,6 @@
-# Unreleased
+# 0.1.0
 
+- Add `useDisposable` hook.
 - Bump `leancode_lint` dev dependency to `12.0.0`.
 - Bump `custom_lint` dev dependency to `0.6.4`.
 

--- a/packages/leancode_hooks/README.md
+++ b/packages/leancode_hooks/README.md
@@ -22,6 +22,7 @@ so you won't have to depend on it.
 - [useBlocState](lib/src/use_bloc_state.dart)
 - [useDebounce](lib/src/use_debounce.dart)
 - [useDeclarativeTextEditingController](lib/src/use_decarative_text_editing_controller.dart)
+- [useDisposable](lib/src/use_disposable.dart)
 - [useFocused](lib/src/use_focused.dart)
 - [usePostFrameEffect](lib/src/use_post_frame_effect.dart)
 - [useStreamListener](lib/src/use_stream_listener.dart)

--- a/packages/leancode_hooks/lib/leancode_hooks.dart
+++ b/packages/leancode_hooks/lib/leancode_hooks.dart
@@ -5,6 +5,7 @@ export 'src/use_bloc_listener.dart';
 export 'src/use_bloc_state.dart';
 export 'src/use_debounce.dart';
 export 'src/use_decarative_text_editing_controller.dart';
+export 'src/use_disposable.dart';
 export 'src/use_focused.dart';
 export 'src/use_post_frame_effect.dart';
 export 'src/use_stream_listener.dart';

--- a/packages/leancode_hooks/lib/src/use_disposable.dart
+++ b/packages/leancode_hooks/lib/src/use_disposable.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+
+/// Creates and memoizes an instance created using [builder].
+/// On unmount, executes [dispose] in order to cleanup resources.
+T useDisposable<T>({
+  required ValueGetter<T> builder,
+  required void Function(T) dispose,
+  List<Object?> keys = const <Object>[],
+}) {
+  final value = useMemoized(builder, keys);
+
+  useEffect(
+    () => () => dispose(value),
+    [value],
+  );
+
+  return value;
+}

--- a/packages/leancode_hooks/pubspec.yaml
+++ b/packages/leancode_hooks/pubspec.yaml
@@ -1,13 +1,13 @@
 name: leancode_hooks
-version: 0.0.6
+version: 0.1.0
 homepage: https://github.com/leancodepl/flutter_corelibrary/tree/master/packages/leancode_hooks
 repository: https://github.com/leancodepl/flutter_corelibrary
 description: >-
   Hooks we often use, all gathered in one place.
 
 environment:
-  sdk: '>=3.0.0 <4.0.0'
-  flutter: '>=3.10.0 <4.0.0'
+  sdk: ">=3.0.0 <4.0.0"
+  flutter: ">=3.10.0 <4.0.0"
 
 dependencies:
   bloc: ^8.0.3


### PR DESCRIPTION
Since `flutter_hooks` doesn't provide a built-in way to dispose resources, and we often use a hook like that in our project (and in packages as well - `leancode_hooks` includes 4 instances of this pattern), I propose adding a new hook that simplifies the disposal of unused resources if an instance of a class supports that.