### PR TITLE
Support Dart 3.6

### DIFF
--- a/.github/workflows/leancode_lint-publish.yml
+++ b/.github/workflows/leancode_lint-publish.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Dart
         uses: dart-lang/setup-dart@v1
         with:
-          sdk: 3.5
+          sdk: 3.6
 
       - name: Publish and release
         uses: leancodepl/mobile-tools/.github/actions/pub-release@pub-release-v1

--- a/.github/workflows/leancode_lint-test.yml
+++ b/.github/workflows/leancode_lint-test.yml
@@ -20,7 +20,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - version: 3.24.x
           - version: 3.27.x
 
     defaults:

--- a/.github/workflows/leancode_lint-test.yml
+++ b/.github/workflows/leancode_lint-test.yml
@@ -21,6 +21,7 @@ jobs:
       matrix:
         include:
           - version: 3.24.x
+          - version: 3.27.x
 
     defaults:
       run:

--- a/packages/leancode_lint/CHANGELOG.md
+++ b/packages/leancode_lint/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 14.4.0
+
+- Support Flutter 3.27 and Dart 3.6
+
 # 14.3.0
 
 - Support `custom_lint` 0.7.0

--- a/packages/leancode_lint/lib/lints/add_cubit_suffix_for_cubits.dart
+++ b/packages/leancode_lint/lib/lints/add_cubit_suffix_for_cubits.dart
@@ -1,5 +1,5 @@
 import 'package:analyzer/dart/ast/ast.dart';
-import 'package:analyzer/error/error.dart';
+import 'package:analyzer/error/error.dart' hide LintCode;
 import 'package:analyzer/error/listener.dart';
 import 'package:custom_lint_builder/custom_lint_builder.dart';
 

--- a/packages/leancode_lint/lib/lints/avoid_conditional_hooks.dart
+++ b/packages/leancode_lint/lib/lints/avoid_conditional_hooks.dart
@@ -1,6 +1,6 @@
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/token.dart';
-import 'package:analyzer/error/error.dart';
+import 'package:analyzer/error/error.dart' hide LintCode;
 import 'package:analyzer/error/listener.dart';
 import 'package:custom_lint_builder/custom_lint_builder.dart';
 import 'package:leancode_lint/helpers.dart';

--- a/packages/leancode_lint/lib/lints/avoid_single_child_in_multi_child_widget.dart
+++ b/packages/leancode_lint/lib/lints/avoid_single_child_in_multi_child_widget.dart
@@ -1,5 +1,5 @@
 import 'package:analyzer/dart/ast/ast.dart';
-import 'package:analyzer/error/error.dart';
+import 'package:analyzer/error/error.dart' hide LintCode;
 import 'package:analyzer/error/listener.dart';
 import 'package:custom_lint_builder/custom_lint_builder.dart';
 import 'package:leancode_lint/utils.dart';

--- a/packages/leancode_lint/lib/lints/avoid_single_child_in_multi_child_widget.dart
+++ b/packages/leancode_lint/lib/lints/avoid_single_child_in_multi_child_widget.dart
@@ -135,15 +135,14 @@ class AvoidSingleChildInMultiChildWidgets extends DartLintRule {
     }
 
     bool checkExpression(CollectionElement expression) {
-      switch (expression) {
-        case Expression():
-          return true;
-        case ForElement() || MapLiteralEntry() || SpreadElement():
-          return false;
-        case IfElement(:final thenElement, :final elseElement):
-          return checkExpression(thenElement) &&
-              (elseElement == null || checkExpression(elseElement));
-      }
+      return switch (expression) {
+        Expression() => true,
+        ForElement() || MapLiteralEntry() || SpreadElement() => false,
+        IfElement(:final thenElement, :final elseElement) =>
+          checkExpression(thenElement) &&
+              (elseElement == null || checkExpression(elseElement)),
+        NullAwareElement(:final value) => checkExpression(value)
+      };
     }
 
     return checkExpression(list.elements.first);

--- a/packages/leancode_lint/lib/lints/catch_parameter_names.dart
+++ b/packages/leancode_lint/lib/lints/catch_parameter_names.dart
@@ -1,5 +1,5 @@
 import 'package:analyzer/dart/ast/ast.dart';
-import 'package:analyzer/error/error.dart';
+import 'package:analyzer/error/error.dart' hide LintCode;
 import 'package:analyzer/error/listener.dart';
 import 'package:custom_lint_builder/custom_lint_builder.dart';
 

--- a/packages/leancode_lint/lib/lints/constructor_parameters_and_fields_should_have_the_same_order.dart
+++ b/packages/leancode_lint/lib/lints/constructor_parameters_and_fields_should_have_the_same_order.dart
@@ -1,5 +1,5 @@
 import 'package:analyzer/dart/ast/ast.dart';
-import 'package:analyzer/error/error.dart';
+import 'package:analyzer/error/error.dart' hide LintCode;
 import 'package:analyzer/error/listener.dart';
 import 'package:custom_lint_builder/custom_lint_builder.dart';
 

--- a/packages/leancode_lint/lib/lints/hook_widget_does_not_use_hooks.dart
+++ b/packages/leancode_lint/lib/lints/hook_widget_does_not_use_hooks.dart
@@ -1,5 +1,5 @@
 import 'package:analyzer/dart/ast/ast.dart';
-import 'package:analyzer/error/error.dart';
+import 'package:analyzer/error/error.dart' hide LintCode;
 import 'package:analyzer/error/listener.dart';
 import 'package:analyzer/source/source_range.dart';
 import 'package:custom_lint_builder/custom_lint_builder.dart';

--- a/packages/leancode_lint/lib/lints/prefix_widgets_returning_slivers.dart
+++ b/packages/leancode_lint/lib/lints/prefix_widgets_returning_slivers.dart
@@ -1,5 +1,5 @@
 import 'package:analyzer/dart/ast/ast.dart';
-import 'package:analyzer/error/error.dart';
+import 'package:analyzer/error/error.dart' hide LintCode;
 import 'package:analyzer/error/listener.dart';
 import 'package:custom_lint_builder/custom_lint_builder.dart';
 import 'package:leancode_lint/helpers.dart';

--- a/packages/leancode_lint/lib/lints/start_comments_with_space.dart
+++ b/packages/leancode_lint/lib/lints/start_comments_with_space.dart
@@ -1,5 +1,5 @@
 import 'package:analyzer/dart/ast/token.dart';
-import 'package:analyzer/error/error.dart';
+import 'package:analyzer/error/error.dart' hide LintCode;
 import 'package:analyzer/error/listener.dart';
 import 'package:custom_lint_builder/custom_lint_builder.dart';
 import 'package:leancode_lint/helpers.dart';

--- a/packages/leancode_lint/lib/lints/use_instead_type.dart
+++ b/packages/leancode_lint/lib/lints/use_instead_type.dart
@@ -1,6 +1,6 @@
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/element/element.dart';
-import 'package:analyzer/error/error.dart';
+import 'package:analyzer/error/error.dart' hide LintCode;
 import 'package:analyzer/error/listener.dart';
 import 'package:custom_lint_builder/custom_lint_builder.dart';
 

--- a/packages/leancode_lint/pubspec.yaml
+++ b/packages/leancode_lint/pubspec.yaml
@@ -1,5 +1,5 @@
 name: leancode_lint
-version: 14.3.0
+version: 14.4.0
 homepage: https://github.com/leancodepl/flutter_corelibrary/tree/master/packages/leancode_lint
 repository: https://github.com/leancodepl/flutter_corelibrary
 description: Robust, high-quality lint rules used at LeanCode.

--- a/packages/leancode_lint/pubspec.yaml
+++ b/packages/leancode_lint/pubspec.yaml
@@ -9,7 +9,7 @@ topics:
   - lints
 
 environment:
-  sdk: ">=3.5.0 <4.0.0"
+  sdk: ">=3.6.0 <4.0.0"
 
 dependencies:
   analyzer: ^6.11.0

--- a/packages/leancode_lint/pubspec.yaml
+++ b/packages/leancode_lint/pubspec.yaml
@@ -12,6 +12,6 @@ environment:
   sdk: ">=3.5.0 <4.0.0"
 
 dependencies:
-  analyzer: ^6.7.0
+  analyzer: ^6.11.0
   analyzer_plugin: ^0.11.3
   custom_lint_builder: ^0.7.0

--- a/packages/leancode_lint/test/lints_test_app/pubspec.lock
+++ b/packages/leancode_lint/test/lints_test_app/pubspec.lock
@@ -249,7 +249,7 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "14.3.0"
+    version: "14.4.0"
   logging:
     dependency: transitive
     description:

--- a/packages/leancode_lint/test/lints_test_app/pubspec.lock
+++ b/packages/leancode_lint/test/lints_test_app/pubspec.lock
@@ -5,23 +5,23 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: f256b0c0ba6c7577c15e2e4e114755640a875e885099367bf6e012b19314c834
+      sha256: "16e298750b6d0af7ce8a3ba7c18c69c3785d11b15ec83f6dcd0ad2a0009b3cab"
       url: "https://pub.dev"
     source: hosted
-    version: "72.0.0"
+    version: "76.0.0"
   _macros:
     dependency: transitive
     description: dart
     source: sdk
-    version: "0.3.2"
+    version: "0.3.3"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: b652861553cd3990d8ed361f7979dc6d7053a9ac8843fa73820ab68ce5410139
+      sha256: "1f14db053a8c23e260789e9b0980fa27f2680dd640932cae5e1137cce0e46e1e"
       url: "https://pub.dev"
     source: hosted
-    version: "6.7.0"
+    version: "6.11.0"
   analyzer_plugin:
     dependency: transitive
     description:
@@ -98,10 +98,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      sha256: a1ace0a119f20aabc852d165077c036cd864315bd99b7eaa10a60100341941bf
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.0"
   convert:
     dependency: transitive
     description:
@@ -146,10 +146,10 @@ packages:
     dependency: transitive
     description:
       name: custom_lint_visitor
-      sha256: "8aeb3b6ae2bb765e7716b93d1d10e8356d04e0ff6d7592de6ee04e0dd7d6587d"
+      sha256: bfe9b7a09c4775a587b58d10ebb871d4fe618237639b1e84d5ec62d7dfef25f9
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0+6.7.0"
+    version: "1.0.0+6.11.0"
   dart_style:
     dependency: transitive
     description:
@@ -262,10 +262,10 @@ packages:
     dependency: transitive
     description:
       name: macros
-      sha256: "0acaed5d6b7eab89f63350bccd82119e6c602df0f391260d0e32b5e23db79536"
+      sha256: "1d9e801cd66f7ea3663c45fc708450db1fa57f988142c64289142c9b7ee80656"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.2-main.4"
+    version: "0.1.3-main.0"
   matcher:
     dependency: transitive
     description:
@@ -358,7 +358,7 @@ packages:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.99"
+    version: "0.0.0"
   sliver_tools:
     dependency: "direct main"
     description:

--- a/packages/leancode_lint/test/lints_test_app/pubspec.lock
+++ b/packages/leancode_lint/test/lints_test_app/pubspec.lock
@@ -488,5 +488,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.5.0 <4.0.0"
+  dart: ">=3.6.0 <4.0.0"
   flutter: ">=3.0.0"

--- a/packages/leancode_lint/test/lints_test_app/pubspec.yaml
+++ b/packages/leancode_lint/test/lints_test_app/pubspec.yaml
@@ -6,7 +6,7 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: '>=3.5.0 <4.0.0'
+  sdk: '>=3.6.0 <4.0.0'
 
 dependencies:
   flutter:


### PR DESCRIPTION
- Closes #394
- `package:analyzer` went back to exporting its own `LintCode`, so it has to be hidden again