### PR TITLE
Upgrade rxdart in debug_page

### DIFF
--- a/.github/workflows/leancode_debug_page-publish.yml
+++ b/.github/workflows/leancode_debug_page-publish.yml
@@ -25,12 +25,12 @@ jobs:
       - name: Set up Dart
         uses: dart-lang/setup-dart@v1
         with:
-          sdk: 3.3
+          sdk: 3.5
 
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: 3.19.x
+          flutter-version: 3.24.x
           cache: true
 
       - name: Publish and release

--- a/.github/workflows/leancode_debug_page-test.yml
+++ b/.github/workflows/leancode_debug_page-test.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - version: '3.19.x'
+          - version: '3.24.x'
           - channel: 'stable'
 
     defaults:

--- a/packages/leancode_debug_page/CHANGELOG.md
+++ b/packages/leancode_debug_page/CHANGELOG.md
@@ -1,10 +1,9 @@
-
 ## 2.0.0
 
-- Bumped `rxdart` dependency to `^0.28.0`
+- Bump `rxdart` dependency to `^0.28.0`
 - **Breaking:** Bump minimum Dart vesion to 3.5.0
-- Bumped `custom_lint` dependency to `^0.7.0`
-- Bumped `leancode_lint` dependency to `^14.0.0`
+- Bump `custom_lint` dependency to `^0.7.0`
+- Bump `leancode_lint` dependency to `^14.0.0`
 
 ## 1.0.2
 

--- a/packages/leancode_debug_page/CHANGELOG.md
+++ b/packages/leancode_debug_page/CHANGELOG.md
@@ -9,3 +9,10 @@
 ## 1.0.2
 
 - Vendor shake package to avoid using obsolete version of sensors_plus
+
+## 2.0.0
+
+- Bumped `rxdart` dependency to `^0.28.0`
+- **Breaking:** Bump minimum Dart vesion to 3.5.0
+- Bumped `custom_lint` dependency to `^0.7.0`
+- Bumped `leancode_lint` dependency to `^14.0.0`

--- a/packages/leancode_debug_page/CHANGELOG.md
+++ b/packages/leancode_debug_page/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 2.0.0
 
 - Bump `rxdart` dependency to `^0.28.0`
-- **Breaking:** Bump minimum Dart vesion to 3.5.0
+- **Breaking:** Bump minimum Dart version to 3.5.0
 - Bump `custom_lint` dependency to `^0.7.0`
 - Bump `leancode_lint` dependency to `^14.0.0`
 

--- a/packages/leancode_debug_page/CHANGELOG.md
+++ b/packages/leancode_debug_page/CHANGELOG.md
@@ -1,14 +1,3 @@
-## 1.0.0
-
-- Initial release
-
-## 1.0.1
-
-- Fix screenshots in README.md
-
-## 1.0.2
-
-- Vendor shake package to avoid using obsolete version of sensors_plus
 
 ## 2.0.0
 
@@ -16,3 +5,15 @@
 - **Breaking:** Bump minimum Dart vesion to 3.5.0
 - Bumped `custom_lint` dependency to `^0.7.0`
 - Bumped `leancode_lint` dependency to `^14.0.0`
+
+## 1.0.2
+
+- Vendor shake package to avoid using obsolete version of sensors_plus
+
+## 1.0.1
+
+- Fix screenshots in README.md
+
+## 1.0.0
+
+- Initial release

--- a/packages/leancode_debug_page/README.md
+++ b/packages/leancode_debug_page/README.md
@@ -1,5 +1,8 @@
 # leancode_debug_page
 
+[![leancode_debug_page pub.dev badge][pub-badge]][pub-badge-link]
+[![][build-badge]][build-badge-link]
+
 A debug page that gathers HTTP requests and logger logs. Features:
 
 - Detailed information about requests (request, response) and logs
@@ -102,3 +105,10 @@ For gathering logs from loggers, this package relies on listening to `Logger.roo
    Built with ☕️ by <a href="https://leancode.co/?utm_source=readme&utm_medium=leancode_debug_page_package">LeanCode</a>
    </p>
 </p>
+
+
+
+[pub-badge]: https://img.shields.io/pub/v/leancode_debug_page
+[pub-badge-link]: https://pub.dev/packages/leancode_debug_page
+[build-badge]: https://img.shields.io/github/actions/workflow/status/leancodepl/flutter_corelibrary/leancode_debug_page-test.yml?branch=master
+[build-badge-link]: https://github.com/leancodepl/flutter_corelibrary/actions/workflows/leancode_debug_page-test.yml

--- a/packages/leancode_debug_page/example/pubspec.lock
+++ b/packages/leancode_debug_page/example/pubspec.lock
@@ -37,10 +37,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      sha256: a1ace0a119f20aabc852d165077c036cd864315bd99b7eaa10a60100341941bf
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.0"
   cross_file:
     dependency: transitive
     description:
@@ -140,33 +140,33 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      sha256: "7bb2830ebd849694d1ec25bf1f44582d6ac531a57a365a803a6034ff751d2d06"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.0"
+    version: "10.0.7"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      sha256: "9491a714cca3667b60b5c420da8217e6de0d1ba7a5ec322fab01758f6998f379"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.8"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.1"
   leancode_debug_page:
     dependency: "direct main"
     description:
       path: ".."
       relative: true
     source: path
-    version: "1.0.1"
+    version: "1.0.2"
   lints:
     dependency: transitive
     description:
@@ -195,18 +195,18 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.15.0"
   mime:
     dependency: transitive
     description:
@@ -291,10 +291,10 @@ packages:
     dependency: transitive
     description:
       name: rxdart
-      sha256: "0c7c0cedd93788d996e33041ffecda924cc54389199cde4e6a34b440f50044cb"
+      sha256: "5c3004a4a8dbb94bd4bf5412a4def4acdaa12e12f269737a5751369e12d1a962"
       url: "https://pub.dev"
     source: hosted
-    version: "0.27.7"
+    version: "0.28.0"
   sensors_plus:
     dependency: transitive
     description:
@@ -331,7 +331,7 @@ packages:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.99"
+    version: "0.0.0"
   source_span:
     dependency: transitive
     description:
@@ -352,10 +352,10 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
+      sha256: "9f47fd3630d76be3ab26f0ee06d213679aa425996925ff3feffdec504931c377"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.1"
+    version: "1.12.0"
   stream_channel:
     dependency: transitive
     description:
@@ -368,10 +368,10 @@ packages:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      sha256: "688af5ed3402a4bde5b3a6c15fd768dbf2621a614950b17f04626c431ab3c4c3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   term_glyph:
     dependency: transitive
     description:
@@ -384,10 +384,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      sha256: "664d3a9a64782fcdeb83ce9c6b39e78fd2971d4e37827b9b06c3aa1edc5e760c"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1"
+    version: "0.7.3"
   typed_data:
     dependency: transitive
     description:
@@ -448,10 +448,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
+      sha256: f6be3ed8bd01289b34d679c2b62226f63c0e69f9fd2e50a6b3c1c729a961041b
       url: "https://pub.dev"
     source: hosted
-    version: "13.0.0"
+    version: "14.3.0"
   web:
     dependency: transitive
     description:
@@ -477,5 +477,5 @@ packages:
     source: hosted
     version: "1.0.3"
 sdks:
-  dart: ">=3.3.0 <4.0.0"
-  flutter: ">=3.19.0"
+  dart: ">=3.5.0 <4.0.0"
+  flutter: ">=3.24.0"

--- a/packages/leancode_debug_page/pubspec.yaml
+++ b/packages/leancode_debug_page/pubspec.yaml
@@ -1,5 +1,5 @@
 name: leancode_debug_page
-version: 1.0.2
+version: 2.0.0
 homepage: https://github.com/leancodepl/flutter_corelibrary/tree/master/packages/leancode_debug_page
 repository: https://github.com/leancodepl/flutter_corelibrary
 description: >-

--- a/packages/leancode_debug_page/pubspec.yaml
+++ b/packages/leancode_debug_page/pubspec.yaml
@@ -6,23 +6,23 @@ description: >-
   A package providing a debug page which shows outgoing http requests and Logger logs
 
 environment:
-  sdk: '>=3.0.0 <4.0.0'
-  flutter: ">=3.10.0"
+  sdk: '>=3.5.0 <4.0.0'
+  flutter: ">=3.24.0"
 
 dependencies:
   flutter:
     sdk: flutter
   http: ^1.1.0
   logging: ^1.2.0
-  rxdart: ^0.27.7
+  rxdart: ^0.28.0
   sensors_plus: ^5.0.1
   share_plus: ^9.0.0
 
 dev_dependencies:
-  custom_lint: ^0.6.4
+  custom_lint: ^0.7.0
   flutter_test:
     sdk: flutter
-  leancode_lint: ^12.1.0
+  leancode_lint: ^14.0.0
   mocktail: ^1.0.3
 
 flutter:

--- a/packages/leancode_debug_page/test/logging_http_client_test.dart
+++ b/packages/leancode_debug_page/test/logging_http_client_test.dart
@@ -1,3 +1,6 @@
+// The arguments provided in this file are explicitly included for clarity in tests,
+// even though they may be redundant. This improves readability and ensures the test cases
+// clearly show all parameters being tested.
 // ignore_for_file: avoid_redundant_argument_values
 
 import 'package:flutter_test/flutter_test.dart';


### PR DESCRIPTION
Changes required to upgrade flutter version in [template app](https://github.com/leancodepl/leancode_flutter_template), specifically upgrade of rxdart to 0.28.0 was needed which caused the necessity to upgrade:

- leancode_lint to 14.0.0 (which requires raising min dart sdk version to 3.5.0)

summing up 
- rx_dart: ^0.27.7 -> ^0.28.0
- leancode_lint: 13.0.0 -> 14.0.0
- min dart sdk: -> 3.5.0
- dart sdk version in testing workflows adjusted accordingly

Please let me know about the approach taken here. For now in [pr upgrading flutter in template](https://github.com/leancodepl/leancode_flutter_template/pull/340) i'm using ref from the last commit in this branch as dependency; previously it was imported as package. Should there be new release planned or should we stick to getting package from ref? If so am I allowed to merge it to main?  