### PR TITLE
Change version number from 3.0.0 to 2.0.0

### DIFF
--- a/packages/enhanced_gradients/CHANGELOG.md
+++ b/packages/enhanced_gradients/CHANGELOG.md
@@ -1,10 +1,6 @@
-## 3.0.0
-
-- BREAKING CHANGE: Raise minimum Flutter version to 3.27.0, which supports wide gamut color spaces.
-
 ## 2.0.0
 
-- BREAKING CHANGE: Raise minimum Flutter version to 3.19.0. Previous versions of enhanced_gradients were incompatible with Flutter 3.19 due to dependency constraints.
+- BREAKING CHANGE: Raise minimum Flutter version to 3.27.0, which supports wide gamut color spaces.
 
 ## 1.0.2
 

--- a/packages/enhanced_gradients/pubspec.yaml
+++ b/packages/enhanced_gradients/pubspec.yaml
@@ -1,5 +1,5 @@
 name: enhanced_gradients
-version: 3.0.0
+version: 2.0.0
 homepage: https://github.com/leancodepl/flutter_corelibrary/tree/master/packages/enhanced_gradients
 repository: https://github.com/leancodepl/flutter_corelibrary
 description: >-


### PR DESCRIPTION
I didn't notice that 2.0.0 wasn't ever released, so I would change the version number back to 2.0.0 and release it this time.