### PR TITLE
Use positional arguments instead of manual string interpolation

### DIFF
--- a/packages/leancode_lint/CHANGELOG.md
+++ b/packages/leancode_lint/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- chore: Refactor lint codes to use built-in positional parameters.
+
 # 15.0.0
 
 - Enable the following lints:

--- a/packages/leancode_lint/lib/leancode_lint.dart
+++ b/packages/leancode_lint/lib/leancode_lint.dart
@@ -17,15 +17,15 @@ PluginBase createPlugin() => _Linter();
 class _Linter extends PluginBase {
   @override
   List<LintRule> getLintRules(CustomLintConfigs configs) => [
-        StartCommentsWithSpace(),
+        const StartCommentsWithSpace(),
         ...UseDesignSystemItem.getRulesListFromConfigs(configs),
         PrefixWidgetsReturningSlivers.fromConfigs(configs),
-        AddCubitSuffixForYourCubits(),
-        CatchParameterNames(),
-        AvoidConditionalHooks(),
-        HookWidgetDoesNotUseHooks(),
-        ConstructorParametersAndFieldsShouldHaveTheSameOrder(),
-        AvoidSingleChildInMultiChildWidgets(),
+        const AddCubitSuffixForYourCubits(),
+        const CatchParameterNames(),
+        const AvoidConditionalHooks(),
+        const HookWidgetDoesNotUseHooks(),
+        const ConstructorParametersAndFieldsShouldHaveTheSameOrder(),
+        const AvoidSingleChildInMultiChildWidgets(),
       ];
 
   @override

--- a/packages/leancode_lint/lib/lints/add_cubit_suffix_for_cubits.dart
+++ b/packages/leancode_lint/lib/lints/add_cubit_suffix_for_cubits.dart
@@ -6,9 +6,15 @@ import 'package:custom_lint_builder/custom_lint_builder.dart';
 /// Displays warning for cubits which do not have the `Cubit` suffix in their
 /// class name.
 class AddCubitSuffixForYourCubits extends DartLintRule {
-  AddCubitSuffixForYourCubits() : super(code: _getLintCode());
-
-  static const ruleName = 'add_cubit_suffix_for_your_cubits';
+  const AddCubitSuffixForYourCubits()
+      : super(
+          code: const LintCode(
+            name: 'add_cubit_suffix_for_your_cubits',
+            problemMessage: 'Add Cubit suffix for your cubits.',
+            correctionMessage: 'Ex. {0}Cubit',
+            errorSeverity: ErrorSeverity.WARNING,
+          ),
+        );
 
   @override
   void run(
@@ -30,7 +36,8 @@ class AddCubitSuffixForYourCubits extends DartLintRule {
 
         reporter.atToken(
           node.name,
-          _getLintCode(node.name.lexeme),
+          code,
+          arguments: [node.name.lexeme],
         );
       },
     );
@@ -45,20 +52,4 @@ class AddCubitSuffixForYourCubits extends DartLintRule {
           ).isSuperOf(element),
         _ => false,
       };
-
-  static LintCode _getLintCode([String? className]) {
-    const problemMessageBase = 'Add Cubit suffix for your cubits.';
-
-    final exampleName = switch (className) {
-      final name? => '${name}Cubit',
-      null => null,
-    };
-
-    return LintCode(
-      name: ruleName,
-      problemMessage: problemMessageBase,
-      correctionMessage: exampleName != null ? 'Ex. $exampleName' : null,
-      errorSeverity: ErrorSeverity.WARNING,
-    );
-  }
 }

--- a/packages/leancode_lint/lib/lints/avoid_conditional_hooks.dart
+++ b/packages/leancode_lint/lib/lints/avoid_conditional_hooks.dart
@@ -7,9 +7,14 @@ import 'package:leancode_lint/helpers.dart';
 
 /// Displays warning for conditional hooks usage.
 class AvoidConditionalHooks extends DartLintRule {
-  AvoidConditionalHooks() : super(code: _getLintCode());
-
-  static const ruleName = 'avoid_conditional_hooks';
+  const AvoidConditionalHooks()
+      : super(
+          code: const LintCode(
+            name: 'avoid_conditional_hooks',
+            problemMessage: "Don't use hooks conditionally",
+            errorSeverity: ErrorSeverity.WARNING,
+          ),
+        );
 
   @override
   void run(
@@ -37,7 +42,7 @@ class AvoidConditionalHooks extends DartLintRule {
           hookExpressions.where((e) => _isConditional(firstReturn, e, node));
 
       for (final hookExpression in hooksCalledConditionally) {
-        reporter.atNode(hookExpression, _getLintCode());
+        reporter.atNode(hookExpression, code);
       }
     });
   }
@@ -98,10 +103,4 @@ class AvoidConditionalHooks extends DartLintRule {
     return isConditional(node, child: node) ||
         (firstReturn != null && isBefore(firstReturn, node));
   }
-
-  static LintCode _getLintCode() => const LintCode(
-        name: ruleName,
-        problemMessage: "Don't use hooks conditionally",
-        errorSeverity: ErrorSeverity.WARNING,
-      );
 }

--- a/packages/leancode_lint/lib/lints/avoid_single_child_in_multi_child_widget.dart
+++ b/packages/leancode_lint/lib/lints/avoid_single_child_in_multi_child_widget.dart
@@ -6,15 +6,16 @@ import 'package:leancode_lint/utils.dart';
 
 /// Enforces that some widgets that accept multiple children do not have a single child.
 class AvoidSingleChildInMultiChildWidgets extends DartLintRule {
-  AvoidSingleChildInMultiChildWidgets() : super(code: _createCode(''));
-
-  static LintCode _createCode(String name) => LintCode(
-        name: 'avoid_single_child_in_multi_child_widgets',
-        problemMessage: 'Avoid using $name with a single child.',
-        correctionMessage:
-            'Remove the $name and achieve the same result using dedicated widgets.',
-        errorSeverity: ErrorSeverity.WARNING,
-      );
+  const AvoidSingleChildInMultiChildWidgets()
+      : super(
+          code: const LintCode(
+            name: 'avoid_single_child_in_multi_child_widgets',
+            problemMessage: 'Avoid using {0} with a single child.',
+            correctionMessage:
+                'Remove the {0} and achieve the same result using dedicated widgets.',
+            errorSeverity: ErrorSeverity.WARNING,
+          ),
+        );
 
   static const _complain = [
     (
@@ -122,7 +123,8 @@ class AvoidSingleChildInMultiChildWidgets extends DartLintRule {
       if (_hasSingleElement(list)) {
         reporter.atNode(
           constructorName,
-          _createCode(constructorName.name2.lexeme),
+          code,
+          arguments: [constructorName.name2.lexeme],
         );
       }
     }

--- a/packages/leancode_lint/lib/lints/catch_parameter_names.dart
+++ b/packages/leancode_lint/lib/lints/catch_parameter_names.dart
@@ -7,15 +7,15 @@ import 'package:custom_lint_builder/custom_lint_builder.dart';
 /// - if it's a catch-all, the exception should be named `err` and the stacktrace `st`
 /// - if it's a typed catch, the stacktrace has to be named `st`
 class CatchParameterNames extends DartLintRule {
-  CatchParameterNames()
-      : super(code: _createCode(_CatchClauseParameter.exception));
-
-  static LintCode _createCode(_CatchClauseParameter param) => LintCode(
-        name: 'catch_parameter_names',
-        problemMessage: 'Parameter name for the ${param.name} is non-standard.',
-        correctionMessage: 'Rename the parameter to `${param.preferredName}`.',
-        errorSeverity: ErrorSeverity.WARNING,
-      );
+  const CatchParameterNames()
+      : super(
+          code: const LintCode(
+            name: 'catch_parameter_names',
+            problemMessage: 'Parameter name for the {0} is non-standard.',
+            correctionMessage: 'Rename the parameter to {1}`.',
+            errorSeverity: ErrorSeverity.WARNING,
+          ),
+        );
 
   @override
   void run(
@@ -50,7 +50,8 @@ class CatchParameterNames extends DartLintRule {
         !{'_', param.preferredName}.contains(node.name.lexeme)) {
       reporter.atNode(
         node,
-        _createCode(param),
+        code,
+        arguments: [param.name, param.preferredName],
       );
     }
   }

--- a/packages/leancode_lint/lib/lints/constructor_parameters_and_fields_should_have_the_same_order.dart
+++ b/packages/leancode_lint/lib/lints/constructor_parameters_and_fields_should_have_the_same_order.dart
@@ -7,11 +7,16 @@ import 'package:custom_lint_builder/custom_lint_builder.dart';
 /// declared fields order. Works for the both named and unnamed parameters.
 class ConstructorParametersAndFieldsShouldHaveTheSameOrder
     extends DartLintRule {
-  ConstructorParametersAndFieldsShouldHaveTheSameOrder()
-      : super(code: _getLintCode());
-
-  static const ruleName =
-      'constructor_parameters_and_fields_should_have_the_same_order';
+  const ConstructorParametersAndFieldsShouldHaveTheSameOrder()
+      : super(
+          code: const LintCode(
+            name:
+                'constructor_parameters_and_fields_should_have_the_same_order',
+            problemMessage:
+                'Class parameters and fields should have the same order.',
+            errorSeverity: ErrorSeverity.WARNING,
+          ),
+        );
 
   // TODO: disabled until stabilized. Add documentation.
   @override
@@ -34,7 +39,7 @@ class ConstructorParametersAndFieldsShouldHaveTheSameOrder
         final constructors = node.members.whereType<ConstructorDeclaration>();
         for (final constructor in constructors) {
           if (!_hasValidOrder(constructor, fields)) {
-            reporter.atNode(constructor, _getLintCode());
+            reporter.atNode(constructor, code);
           }
         }
       },
@@ -121,11 +126,4 @@ class ConstructorParametersAndFieldsShouldHaveTheSameOrder
 
     return effectiveParameterName == effectiveFieldName;
   }
-
-  static LintCode _getLintCode() => const LintCode(
-        name: ruleName,
-        problemMessage:
-            'Class parameters and fields should have the same order.',
-        errorSeverity: ErrorSeverity.WARNING,
-      );
 }

--- a/packages/leancode_lint/lib/lints/hook_widget_does_not_use_hooks.dart
+++ b/packages/leancode_lint/lib/lints/hook_widget_does_not_use_hooks.dart
@@ -7,9 +7,15 @@ import 'package:leancode_lint/helpers.dart';
 
 /// Displays warning when a `HookWidget` does not use hooks in the build method.
 class HookWidgetDoesNotUseHooks extends DartLintRule {
-  HookWidgetDoesNotUseHooks() : super(code: _getLintCode());
-
-  static const ruleName = 'hook_widget_does_not_use_hooks';
+  const HookWidgetDoesNotUseHooks()
+      : super(
+          code: const LintCode(
+            name: 'hook_widget_does_not_use_hooks',
+            problemMessage: 'This HookWidget does not use hooks.',
+            correctionMessage: 'Convert it to a StatelessWidget',
+            errorSeverity: ErrorSeverity.WARNING,
+          ),
+        );
 
   @override
   void run(
@@ -32,7 +38,7 @@ class HookWidgetDoesNotUseHooks extends DartLintRule {
           return;
         }
 
-        reporter.atNode(diagnosticTarget, _getLintCode());
+        reporter.atNode(diagnosticTarget, code);
       },
     );
   }
@@ -41,13 +47,6 @@ class HookWidgetDoesNotUseHooks extends DartLintRule {
   List<Fix> getFixes() => [
         _ConvertHookWidgetToStatelessWidget(),
       ];
-
-  static LintCode _getLintCode() => const LintCode(
-        name: ruleName,
-        problemMessage: 'This HookWidget does not use hooks.',
-        correctionMessage: 'Convert it to a StatelessWidget',
-        errorSeverity: ErrorSeverity.WARNING,
-      );
 }
 
 class _ConvertHookWidgetToStatelessWidget extends DartFix {

--- a/packages/leancode_lint/lib/lints/prefix_widgets_returning_slivers.dart
+++ b/packages/leancode_lint/lib/lints/prefix_widgets_returning_slivers.dart
@@ -28,7 +28,7 @@ class PrefixWidgetsReturningSlivers extends DartLintRule {
             name: ruleName,
             problemMessage:
                 'Prefix widget names of widgets which return slivers in the build method.',
-            correctionMessage: '{0}',
+            correctionMessage: 'Consider renaming to {0}',
             errorSeverity: ErrorSeverity.WARNING,
           ),
         );
@@ -76,7 +76,7 @@ class PrefixWidgetsReturningSlivers extends DartLintRule {
           reporter.atToken(
             node.name,
             code,
-            arguments: [_getCorrectionMessage(config, node.name.lexeme)],
+            arguments: [_getSuggestedClassName(config, node.name.lexeme)],
           );
         }
       },
@@ -101,7 +101,7 @@ class PrefixWidgetsReturningSlivers extends DartLintRule {
             _hasSliverPrefix(expression.constructorName.type.name2.lexeme),
       );
 
-  static String _getCorrectionMessage(
+  static String _getSuggestedClassName(
     PrefixWidgetsReturningSliversConfig config,
     String className,
   ) {
@@ -121,6 +121,6 @@ class PrefixWidgetsReturningSlivers extends DartLintRule {
       ..write('Sliver')
       ..write(name);
 
-    return 'Consider renaming to $suggested';
+    return suggested.toString();
   }
 }

--- a/packages/leancode_lint/lib/lints/prefix_widgets_returning_slivers.dart
+++ b/packages/leancode_lint/lib/lints/prefix_widgets_returning_slivers.dart
@@ -23,7 +23,15 @@ final class PrefixWidgetsReturningSliversConfig {
 /// `AppPrefix` is specified in the config) prefix in their name.
 class PrefixWidgetsReturningSlivers extends DartLintRule {
   PrefixWidgetsReturningSlivers({required this.config})
-      : super(code: _getLintCode(config));
+      : super(
+          code: const LintCode(
+            name: ruleName,
+            problemMessage:
+                'Prefix widget names of widgets which return slivers in the build method.',
+            correctionMessage: '{0}',
+            errorSeverity: ErrorSeverity.WARNING,
+          ),
+        );
 
   PrefixWidgetsReturningSlivers.fromConfigs(CustomLintConfigs configs)
       : this(
@@ -67,7 +75,8 @@ class PrefixWidgetsReturningSlivers extends DartLintRule {
         if (isSliver) {
           reporter.atToken(
             node.name,
-            _getLintCode(config, node.name.lexeme),
+            code,
+            arguments: [_getCorrectionMessage(config, node.name.lexeme)],
           );
         }
       },
@@ -92,41 +101,26 @@ class PrefixWidgetsReturningSlivers extends DartLintRule {
             _hasSliverPrefix(expression.constructorName.type.name2.lexeme),
       );
 
-  static LintCode _getLintCode(
-    PrefixWidgetsReturningSliversConfig config, [
-    String? className,
-  ]) {
-    const problemMessageBase =
-        'Prefix widget names of widgets which return slivers in the build method.';
+  static String _getCorrectionMessage(
+    PrefixWidgetsReturningSliversConfig config,
+    String className,
+  ) {
+    var name = className;
 
-    final suggestedName = () {
-      var name = className;
-      if (name == null) {
-        return null;
-      }
-      final suggested = StringBuffer();
-      if (name.startsWith('_')) {
-        suggested.write('_');
-        name = name.substring(1);
-      }
-      if (config.applicationPrefix case final applicationPrefix?
-          when name.startsWith(applicationPrefix)) {
-        suggested.write(applicationPrefix);
-        name = name.substring(applicationPrefix.length);
-      }
-      suggested
-        ..write('Sliver')
-        ..write(name);
+    final suggested = StringBuffer();
+    if (name.startsWith('_')) {
+      suggested.write('_');
+      name = name.substring(1);
+    }
+    if (config.applicationPrefix case final applicationPrefix?
+        when name.startsWith(applicationPrefix)) {
+      suggested.write(applicationPrefix);
+      name = name.substring(applicationPrefix.length);
+    }
+    suggested
+      ..write('Sliver')
+      ..write(name);
 
-      return suggested.toString();
-    }();
-
-    return LintCode(
-      name: ruleName,
-      problemMessage: problemMessageBase,
-      correctionMessage:
-          suggestedName != null ? 'Consider renaming to $suggestedName' : null,
-      errorSeverity: ErrorSeverity.WARNING,
-    );
+    return 'Consider renaming to $suggested';
   }
 }

--- a/packages/leancode_lint/lib/lints/start_comments_with_space.dart
+++ b/packages/leancode_lint/lib/lints/start_comments_with_space.dart
@@ -6,15 +6,14 @@ import 'package:leancode_lint/helpers.dart';
 
 /// Forces comments/docs to start with a space.
 class StartCommentsWithSpace extends DartLintRule {
-  StartCommentsWithSpace() : super(code: _createCode(_CommentType.comment));
-
-  static const ruleName = 'start_comments_with_space';
-
-  static LintCode _createCode(_CommentType param) => LintCode(
-        name: ruleName,
-        problemMessage: 'Start ${param.name}s with a space.',
-        errorSeverity: ErrorSeverity.WARNING,
-      );
+  const StartCommentsWithSpace()
+      : super(
+          code: const LintCode(
+            name: 'start_comments_with_space',
+            problemMessage: 'Start {0} with a space.',
+            errorSeverity: ErrorSeverity.WARNING,
+          ),
+        );
 
   @override
   List<Fix> getFixes() {
@@ -32,7 +31,8 @@ class StartCommentsWithSpace extends DartLintRule {
         reporter.atOffset(
           offset: token.offset + contentStart,
           length: 0,
-          errorCode: _createCode(_CommentType.comment),
+          errorCode: code,
+          arguments: [_CommentType.comment.pluralName],
         );
       }
     });
@@ -43,7 +43,8 @@ class StartCommentsWithSpace extends DartLintRule {
           reporter.atOffset(
             offset: token.offset + contentStart,
             length: 0,
-            errorCode: _createCode(_CommentType.doc),
+            errorCode: code,
+            arguments: [_CommentType.doc.pluralName],
           );
         }
       }
@@ -70,8 +71,12 @@ class StartCommentsWithSpace extends DartLintRule {
 }
 
 enum _CommentType {
-  comment,
-  doc;
+  comment('comments'),
+  doc('doc comments');
+
+  const _CommentType(this.pluralName);
+
+  final String pluralName;
 }
 
 class _AddStartingSpaceToComment extends DartFix {

--- a/packages/leancode_lint/lib/lints/use_design_system_item.dart
+++ b/packages/leancode_lint/lib/lints/use_design_system_item.dart
@@ -30,6 +30,9 @@ final class UseDesignSystemItem extends UseInsteadType {
     required Iterable<ForbiddenItem> replacements,
   }) : super(
           lintCodeName: '${ruleName}_$preferredItemName',
+          problemMessage: '{0} is forbidden within this design system.',
+          correctionMessage:
+              'Use the alternative defined in the design system: {1}.',
           replacements: {preferredItemName: replacements.toList()},
         );
 
@@ -48,15 +51,5 @@ final class UseDesignSystemItem extends UseInsteadType {
         replacements: entry.value,
       ),
     );
-  }
-
-  @override
-  String correctionMessage(String preferredItemName) {
-    return 'Use the alternative defined in the design system: $preferredItemName.';
-  }
-
-  @override
-  String problemMessage(String itemName) {
-    return '$itemName is forbidden within this design system.';
   }
 }

--- a/packages/leancode_lint/lib/lints/use_instead_type.dart
+++ b/packages/leancode_lint/lib/lints/use_instead_type.dart
@@ -11,8 +11,10 @@ abstract base class UseInsteadType extends DartLintRule {
   UseInsteadType({
     /// preferred item -> forbidden items
     required Map<String, List<ForbiddenItem>> replacements,
-    required this.lintCodeName,
-    this.errorSeverity = ErrorSeverity.WARNING,
+    required String lintCodeName,
+    required String problemMessage,
+    required String correctionMessage,
+    ErrorSeverity errorSeverity = ErrorSeverity.WARNING,
   })  : _checkers = [
           for (final MapEntry(key: preferredItemName, value: forbidden)
               in replacements.entries)
@@ -30,32 +32,18 @@ abstract base class UseInsteadType extends DartLintRule {
         super(
           code: LintCode(
             name: lintCodeName,
-            problemMessage: 'This item is forbidden',
+            problemMessage: problemMessage,
+            correctionMessage: correctionMessage,
+            errorSeverity: errorSeverity,
           ),
         );
 
   final List<(String preferredItemName, TypeChecker)> _checkers;
-  final String lintCodeName;
-  final ErrorSeverity errorSeverity;
-
-  String problemMessage(String itemName);
-  String correctionMessage(String preferredItemName);
 
   @override
   bool isEnabled(CustomLintConfigs configs) {
     return _checkers.isNotEmpty;
   }
-
-  LintCode _createCode({
-    required String itemName,
-    required String preferredItemName,
-  }) =>
-      LintCode(
-        name: lintCodeName,
-        problemMessage: problemMessage(itemName),
-        correctionMessage: correctionMessage(preferredItemName),
-        errorSeverity: errorSeverity,
-      );
 
   @override
   void run(
@@ -89,10 +77,8 @@ abstract base class UseInsteadType extends DartLintRule {
         if (checker.isExactly(element)) {
           reporter.atNode(
             node,
-            _createCode(
-              itemName: element.displayName,
-              preferredItemName: preferredItemName,
-            ),
+            code,
+            arguments: [element.displayName, preferredItemName],
           );
         }
       } catch (err) {


### PR DESCRIPTION
This PR is purely technical and does not introduce any behavior changes.

Refactors lint codes to use built-in positional parameters (like `{0}`) in lint messages.