### PR TITLE
Make CommandResponse public

### DIFF
--- a/packages/cqrs/CHANGELOG.md
+++ b/packages/cqrs/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 10.0.2
 
-- Make CommandResponse publicly accessible.
+- Make CommandResponse public.
 - Bump `leancode_lint` dev dependency to `12.0.0`.
 - Bump `custom_lint` dev dependency to `0.6.4`.
 

--- a/packages/cqrs/CHANGELOG.md
+++ b/packages/cqrs/CHANGELOG.md
@@ -1,5 +1,6 @@
-# Unreleased
+# 10.0.2
 
+- Make CommandResponse publicly accessible.
 - Bump `leancode_lint` dev dependency to `12.0.0`.
 - Bump `custom_lint` dev dependency to `0.6.4`.
 

--- a/packages/cqrs/lib/cqrs.dart
+++ b/packages/cqrs/lib/cqrs.dart
@@ -64,6 +64,7 @@
 /// code contract generator.
 library;
 
+export 'src/command_response.dart';
 export 'src/cqrs.dart';
 export 'src/cqrs_error.dart';
 export 'src/cqrs_middleware.dart';

--- a/packages/cqrs/pubspec.yaml
+++ b/packages/cqrs/pubspec.yaml
@@ -1,5 +1,5 @@
 name: cqrs
-version: 10.0.1
+version: 10.0.2
 homepage: https://github.com/leancodepl/flutter_corelibrary/tree/master/packages/cqrs
 repository: https://github.com/leancodepl/flutter_corelibrary
 description: >-


### PR DESCRIPTION
`CommandResponse` (formerly `CommandResult`) is used in contracts, so it has to be accessible from outside of this package ([docs](https://github.com/leancodepl/contractsgenerator/blob/f3f2d112f4368f9616e4e7a9e5b90950db25a35b/docs/types.md)). 