### PR TITLE
Improve clearing the API endpoint

### DIFF
--- a/packages/override_api_endpoint/CHANGELOG.md
+++ b/packages/override_api_endpoint/CHANGELOG.md
@@ -1,5 +1,7 @@
-# Unreleased
+# 2.0.0
 
+- Add `clear` as a value for the deeplink query parameter to clear the API endpoint.
+- Do not clear the API endpoint if the deeplink query parameter is not provided.
 - Bump `leancode_lint` dev dependency to `8.0.0`. (#230)
 
 # 1.0.0+2

--- a/packages/override_api_endpoint/lib/src/override_api_endpoint.dart
+++ b/packages/override_api_endpoint/lib/src/override_api_endpoint.dart
@@ -12,6 +12,10 @@ import 'package:shared_preferences/shared_preferences.dart';
 /// endpoint deeplink that contains url encoded API endpoint to be used
 /// eg. `apiAddress` in `app://app/override?apiAddress=https%3A%2F%2Fexample.com`
 ///
+/// To clear the persisted endpoint and return to the default one, use 'clear'
+/// as the query parameter value
+/// eg. `app://app/override?apiAddress=clear`
+///
 /// The `defaultEndpoint` is fallback url that should be used if app does not
 /// have any endpoint introduced via deeplink or if `deeplinkQueryParameter` is
 /// not provided
@@ -34,10 +38,10 @@ Future<Uri> overrideApiEndpoint({
   if (initial != null && initial.path.contains(deeplinkOverrideSegment)) {
     final endpointFromDeeplink =
         initial.queryParameters[deeplinkQueryParameter];
-    if (endpointFromDeeplink?.isEmpty ?? true) {
+    if (endpointFromDeeplink == 'clear') {
       await sharedPreferences.remove(apiEndpointKey);
       apiEndpoint = defaultEndpoint;
-    } else {
+    } else if (endpointFromDeeplink?.isNotEmpty ?? false) {
       apiEndpoint = Uri.parse(endpointFromDeeplink!);
       await sharedPreferences.setString(apiEndpointKey, apiEndpoint.toString());
     }

--- a/packages/override_api_endpoint/pubspec.yaml
+++ b/packages/override_api_endpoint/pubspec.yaml
@@ -1,5 +1,5 @@
 name: override_api_endpoint
-version: 1.0.0+3
+version: 2.0.0
 homepage: https://github.com/leancodepl/flutter_corelibrary/tree/master/packages/override_api_endpoint
 repository: https://github.com/leancodepl/flutter_corelibrary
 description: >-


### PR DESCRIPTION
Previous implementation was clearing API endpoint saved in shared preferences if it was not provided explicity. This makes configuring more than one override endpoint within the app. 

This PR makes clearing the value in shared preferences explicit, allowing to configure multiple urls within the same app.