### PR TITLE
LMG-303: Update SDK constraint to 4.0.0 in overrride_api_endpoint

### DIFF
--- a/packages/override_api_endpoint/pubspec.yaml
+++ b/packages/override_api_endpoint/pubspec.yaml
@@ -9,7 +9,7 @@ description: >-
   is used.
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.12.0 <4.0.0'
   flutter: '>=2.0.0'
 
 dependencies:


### PR DESCRIPTION
The `<3.0.0` sdk constraint is outdated, and it seems to be ignored by pub. That's why we update it to `<4.0.0`.