### PR TITLE
[enhanced_gradients] fix: Exception when using `withOpacity` method

### DIFF
--- a/packages/enhanced_gradients/CHANGELOG.md
+++ b/packages/enhanced_gradients/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.1
+
+- Fix `withOpacity` method in `EnhancedLinearGradient`.
+
 ## 2.0.0
 
 - BREAKING CHANGE: Raise minimum Flutter version to 3.27.0, which supports wide gamut color spaces.

--- a/packages/enhanced_gradients/lib/src/enhanced_gradients.dart
+++ b/packages/enhanced_gradients/lib/src/enhanced_gradients.dart
@@ -38,6 +38,7 @@ class EnhancedLinearGradient extends LinearGradient {
       transform: transform,
     );
   }
+
   const EnhancedLinearGradient._({
     required super.begin,
     required super.end,
@@ -46,6 +47,20 @@ class EnhancedLinearGradient extends LinearGradient {
     required super.tileMode,
     required super.transform,
   });
+
+  @override
+  EnhancedLinearGradient withOpacity(double opacity) {
+    return EnhancedLinearGradient._(
+      begin: begin,
+      end: end,
+      colors: [
+        for (final Color color in colors) color.withValues(alpha: opacity),
+      ],
+      stops: stops,
+      tileMode: tileMode,
+      transform: transform,
+    );
+  }
 }
 
 /// A slightly modified [RadialGradient] that applies a smoother color

--- a/packages/enhanced_gradients/pubspec.yaml
+++ b/packages/enhanced_gradients/pubspec.yaml
@@ -1,5 +1,5 @@
 name: enhanced_gradients
-version: 2.0.0
+version: 2.0.1
 homepage: https://github.com/leancodepl/flutter_corelibrary/tree/master/packages/enhanced_gradients
 repository: https://github.com/leancodepl/flutter_corelibrary
 description: >-

--- a/packages/enhanced_gradients/test/src/enhanced_gradients_test.dart
+++ b/packages/enhanced_gradients/test/src/enhanced_gradients_test.dart
@@ -93,4 +93,22 @@ void main() {
       expect(gradient.stops, expectedStops);
     },
   );
+
+  test('EnhancedLinearGradient.withOpacity works', () {
+    final gradient = EnhancedLinearGradient(
+      colors: const [
+        Color(0xFFFF0000),
+        Color(0xFF00FF00),
+        Color(0xFF0000FF),
+      ],
+    );
+
+    final withOpacity = gradient.withOpacity(0.5);
+
+    expect(withOpacity, isA<EnhancedLinearGradient>());
+    expect(
+      withOpacity.colors.every((color) => color.a == 0.5),
+      isTrue,
+    );
+  });
 }


### PR DESCRIPTION
`LinearGradient` has a method called `withOpacity` that currently throws an exception when executed. This PR fixes it.