### PR TITLE
Stop fetching force update version in the background

### DIFF
--- a/packages/leancode_force_update/lib/src/force_update_guard.dart
+++ b/packages/leancode_force_update/lib/src/force_update_guard.dart
@@ -52,7 +52,8 @@ class ForceUpdateGuard extends StatefulWidget {
   State<ForceUpdateGuard> createState() => _ForceUpdateGuardState();
 }
 
-class _ForceUpdateGuardState extends State<ForceUpdateGuard> {
+class _ForceUpdateGuardState extends State<ForceUpdateGuard>
+    with WidgetsBindingObserver {
   _ForceUpdateGuardState() : _storage = ForceUpdateStorage();
 
   final ForceUpdateStorage _storage;
@@ -60,6 +61,8 @@ class _ForceUpdateGuardState extends State<ForceUpdateGuard> {
   final force = ValueNotifier<bool?>(null);
   late Listenable listenable;
   Timer? _checkForEnforcedUpdateTimer;
+  var _isAppInForeground = true;
+  DateTime? _lastVersionCheckAt;
 
   final _logger = Logger('ForceUpdateGuard');
 
@@ -68,6 +71,46 @@ class _ForceUpdateGuardState extends State<ForceUpdateGuard> {
     super.initState();
 
     init();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    final wasInForeground = _isAppInForeground;
+    _syncForegroundFromLifecycle(state);
+
+    if (wasInForeground && !_isAppInForeground) {
+      _stopTimer();
+    } else if (!wasInForeground && _isAppInForeground) {
+      _startTimer();
+      _checkForUpdateIfIntervalElapsed();
+    }
+  }
+
+  void _syncForegroundFromLifecycle(AppLifecycleState state) {
+    _isAppInForeground = state == AppLifecycleState.resumed;
+  }
+
+  void _startTimer() {
+    _checkForEnforcedUpdateTimer?.cancel();
+    _checkForEnforcedUpdateTimer = Timer.periodic(
+      ForceUpdateGuard.updateCheckingInterval,
+      (_) => _updateAndMaybeApplyVersionsInfo(),
+    );
+  }
+
+  void _stopTimer() {
+    _checkForEnforcedUpdateTimer?.cancel();
+    _checkForEnforcedUpdateTimer = null;
+  }
+
+  void _checkForUpdateIfIntervalElapsed() {
+    if (_lastVersionCheckAt case final lastCheck?
+        when DateTime.now().difference(lastCheck) <
+            ForceUpdateGuard.updateCheckingInterval) {
+      return;
+    }
+
+    unawaited(_updateAndMaybeApplyVersionsInfo());
   }
 
   Future<void> _applyResult({required ForceUpdateResult? result}) async {
@@ -104,13 +147,17 @@ class _ForceUpdateGuardState extends State<ForceUpdateGuard> {
   }
 
   Future<void> init() async {
+    WidgetsBinding.instance.addObserver(this);
+    _syncForegroundFromLifecycle(
+      WidgetsBinding.instance.lifecycleState ?? AppLifecycleState.detached,
+    );
+
     listenable = Listenable.merge([force, widget.controller._suggest]);
     _packageInfo = await PackageInfo.fromPlatform();
 
-    _checkForEnforcedUpdateTimer = Timer.periodic(
-      ForceUpdateGuard.updateCheckingInterval,
-      (_) => _updateAndMaybeApplyVersionsInfo(),
-    );
+    if (_isAppInForeground) {
+      _startTimer();
+    }
 
     final recentResult = await _storage.readMostRecentResult();
     await _applyResult(result: recentResult);
@@ -119,6 +166,8 @@ class _ForceUpdateGuardState extends State<ForceUpdateGuard> {
   }
 
   Future<void> _updateVersionsInfo() async {
+    _lastVersionCheckAt = DateTime.now();
+
     _logger.info('Looking for updates...');
 
     final platform = switch (defaultTargetPlatform) {
@@ -181,7 +230,8 @@ class _ForceUpdateGuardState extends State<ForceUpdateGuard> {
 
   @override
   void dispose() {
-    _checkForEnforcedUpdateTimer?.cancel();
+    WidgetsBinding.instance.removeObserver(this);
+    _stopTimer();
 
     super.dispose();
   }

--- a/packages/leancode_force_update/lib/src/force_update_guard.dart
+++ b/packages/leancode_force_update/lib/src/force_update_guard.dart
@@ -94,7 +94,7 @@ class _ForceUpdateGuardState extends State<ForceUpdateGuard>
     _checkForEnforcedUpdateTimer?.cancel();
     _checkForEnforcedUpdateTimer = Timer.periodic(
       ForceUpdateGuard.updateCheckingInterval,
-      (_) => _updateAndMaybeApplyVersionsInfo(),
+      (_) => unawaited(_updateAndMaybeApplyVersionsInfo()),
     );
   }
 

--- a/packages/leancode_force_update/lib/src/force_update_guard.dart
+++ b/packages/leancode_force_update/lib/src/force_update_guard.dart
@@ -122,9 +122,7 @@ class _ForceUpdateGuardState extends State<ForceUpdateGuard>
       return;
     }
 
-    _updateAndMaybeApplyVersionsInfo().catchError((dynamic err) {
-      _logger.warning('Failed to check for updates', err);
-    });
+    unawaited(_updateAndMaybeApplyVersionsInfo());
   }
 
   Future<void> _applyResult({required ForceUpdateResult? result}) async {
@@ -148,15 +146,20 @@ class _ForceUpdateGuardState extends State<ForceUpdateGuard>
   }
 
   Future<void> _updateAndMaybeApplyVersionsInfo() async {
-    await _updateVersionsInfo();
+    try {
+      await _updateVersionsInfo();
 
-    final recentResult = await _storage.readMostRecentResult();
+      final recentResult = await _storage.readMostRecentResult();
 
-    if ((recentResult?.conclusion == VersionSupportResultDTO.updateRequired &&
-            widget.showForceUpdateScreenImmediately) ||
-        (recentResult?.conclusion == VersionSupportResultDTO.updateSuggested &&
-            widget.showSuggestUpdateDialogImmediately)) {
-      return _applyResult(result: recentResult);
+      if ((recentResult?.conclusion == VersionSupportResultDTO.updateRequired &&
+              widget.showForceUpdateScreenImmediately) ||
+          (recentResult?.conclusion ==
+                  VersionSupportResultDTO.updateSuggested &&
+              widget.showSuggestUpdateDialogImmediately)) {
+        return _applyResult(result: recentResult);
+      }
+    } catch (e) {
+      _logger.warning('Failed to check for updates', e);
     }
   }
 

--- a/packages/leancode_force_update/lib/src/force_update_guard.dart
+++ b/packages/leancode_force_update/lib/src/force_update_guard.dart
@@ -82,7 +82,7 @@ class _ForceUpdateGuardState extends State<ForceUpdateGuard>
       _stopTimer();
     } else if (!wasInForeground && _isAppInForeground) {
       _startTimer();
-      _checkForUpdateIfIntervalElapsed();
+      _updateIfIntervalElapsed();
     }
   }
 
@@ -94,7 +94,7 @@ class _ForceUpdateGuardState extends State<ForceUpdateGuard>
     _checkForEnforcedUpdateTimer?.cancel();
     _checkForEnforcedUpdateTimer = Timer.periodic(
       ForceUpdateGuard.updateCheckingInterval,
-      (_) => unawaited(_updateAndMaybeApplyVersionsInfo()),
+      (_) => _tryForegroundUpdateCheck(),
     );
   }
 
@@ -103,14 +103,28 @@ class _ForceUpdateGuardState extends State<ForceUpdateGuard>
     _checkForEnforcedUpdateTimer = null;
   }
 
-  void _checkForUpdateIfIntervalElapsed() {
+  void _updateIfIntervalElapsed() {
+    if (!_isAppInForeground) {
+      return;
+    }
+
     if (_lastVersionCheckAt case final lastCheck?
         when DateTime.now().difference(lastCheck) <
             ForceUpdateGuard.updateCheckingInterval) {
       return;
     }
 
-    unawaited(_updateAndMaybeApplyVersionsInfo());
+    _tryForegroundUpdateCheck();
+  }
+
+  void _tryForegroundUpdateCheck() {
+    if (!_isAppInForeground) {
+      return;
+    }
+
+    _updateAndMaybeApplyVersionsInfo().catchError((dynamic err) {
+      _logger.warning('Failed to check for updates', err);
+    });
   }
 
   Future<void> _applyResult({required ForceUpdateResult? result}) async {
@@ -162,7 +176,7 @@ class _ForceUpdateGuardState extends State<ForceUpdateGuard>
     final recentResult = await _storage.readMostRecentResult();
     await _applyResult(result: recentResult);
 
-    unawaited(_updateAndMaybeApplyVersionsInfo());
+    _tryForegroundUpdateCheck();
   }
 
   Future<void> _updateVersionsInfo() async {

--- a/packages/leancode_force_update/lib/src/force_update_guard.dart
+++ b/packages/leancode_force_update/lib/src/force_update_guard.dart
@@ -156,8 +156,8 @@ class _ForceUpdateGuardState extends State<ForceUpdateGuard>
               widget.showSuggestUpdateDialogImmediately)) {
         return _applyResult(result: recentResult);
       }
-    } catch (e) {
-      _logger.warning('Failed to check for updates', e);
+    } catch (e, st) {
+      _logger.warning('Failed to check for updates', e, st);
     }
   }
 

--- a/packages/leancode_force_update/lib/src/force_update_guard.dart
+++ b/packages/leancode_force_update/lib/src/force_update_guard.dart
@@ -156,8 +156,8 @@ class _ForceUpdateGuardState extends State<ForceUpdateGuard>
               widget.showSuggestUpdateDialogImmediately)) {
         return _applyResult(result: recentResult);
       }
-    } catch (e, st) {
-      _logger.warning('Failed to check for updates', e, st);
+    } catch (err, st) {
+      _logger.warning('Failed to check for updates', err, st);
     }
   }
 

--- a/packages/leancode_force_update/lib/src/force_update_guard.dart
+++ b/packages/leancode_force_update/lib/src/force_update_guard.dart
@@ -54,9 +54,7 @@ class ForceUpdateGuard extends StatefulWidget {
 
 class _ForceUpdateGuardState extends State<ForceUpdateGuard>
     with WidgetsBindingObserver {
-  _ForceUpdateGuardState() : _storage = ForceUpdateStorage();
-
-  final ForceUpdateStorage _storage;
+  final _storage = ForceUpdateStorage();
   late PackageInfo _packageInfo;
   final force = ValueNotifier<bool?>(null);
   late Listenable listenable;

--- a/packages/leancode_force_update/test/utils.dart
+++ b/packages/leancode_force_update/test/utils.dart
@@ -77,7 +77,8 @@ Future<void> pumpForceUpdateGuard({
     ),
   );
 
-  await tester.pump();
+  tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+  await tester.pumpAndSettle();
 }
 
 void expectForceUpdatePage({required bool value}) {


### PR DESCRIPTION
Fetching in the background would lead to network errors which in turn would trigger our typical implementation of connectivity check