### PR TITLE
Remove deprecated usage

### DIFF
--- a/packages/leancode_lint/CHANGELOG.md
+++ b/packages/leancode_lint/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Add new custom lint:
   - [`missing_equatable_props`](https://github.com/leancodepl/flutter_corelibrary/tree/master/packages/leancode_lint#missing_equatable_props)
+- Replace usages of members deprecated in the analyzer.
 
 # 23.0.0
 

--- a/packages/leancode_lint/lib/src/lints/constructor_parameters_and_fields_should_have_the_same_order.dart
+++ b/packages/leancode_lint/lib/src/lints/constructor_parameters_and_fields_should_have_the_same_order.dart
@@ -3,6 +3,7 @@ import 'package:analyzer/analysis_rule/rule_context.dart';
 import 'package:analyzer/analysis_rule/rule_visitor_registry.dart';
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/error/error.dart';
 
 /// Displays warning when constructor's parameters' order vary from class
@@ -122,7 +123,7 @@ class _Visitor extends SimpleAstVisitor<void> {
   }
 
   bool _isNotSuperFormal(FormalParameter parameter) =>
-      !(parameter.declaredFragment?.element.isSuperFormal ?? false);
+      parameter.declaredFragment?.element is! SuperFormalParameterElement;
 
   bool _compareEffectiveNames(
     FieldDeclaration field,


### PR DESCRIPTION
So that we can go back to full score:

<img width="825" height="410" alt="Screenshot 2026-06-26 at 10 57 38" src="https://github.com/user-attachments/assets/1f8960dc-819b-4aff-b751-15828b177474" />
