### PR TITLE
Add `avoid_build_context_in_blocs` lint

### DIFF
--- a/packages/leancode_lint/CHANGELOG.md
+++ b/packages/leancode_lint/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+- Add new custom lints:
+  - [`avoid_build_context_in_blocs`](https://github.com/leancodepl/flutter_corelibrary/tree/master/packages/leancode_lint#avoid_build_context_in_blocs)
+
 # 24.0.0
 
 - Add new custom lints:
@@ -93,7 +98,7 @@
 - Remove the following lints which have been removed from Dart:
   - [`package_api_docs`](https://dart.dev/tools/linter-rules/package_api_docs)
   - [`unsafe_html`](https://dart.dev/tools/linter-rules/unsafe_html)
-- Disable the [`require_trailing_commas`](https://dart.dev/tools/linter-rules/require_trailing_commas) lint as it conflicts with Dart 3.7 formatter (https://github.com/dart-lang/sdk/issues/60119).
+- Disable the [`require_trailing_commas`](https://dart.dev/tools/linter-rules/require_trailing_commas) lint as it conflicts with Dart 3.7 formatter (<https://github.com/dart-lang/sdk/issues/60119>).
 
 # 15.1.0
 

--- a/packages/leancode_lint/README.md
+++ b/packages/leancode_lint/README.md
@@ -141,6 +141,56 @@ None.
 </details>
 
 <details>
+<summary><code>avoid_build_context_in_blocs</code></summary>
+
+### `avoid_build_context_in_blocs`
+
+**AVOID** letting a `BuildContext` cross into a Bloc/Cubit.
+
+A `BuildContext` couples business logic to the widget tree, which risks stale
+contexts and wrong `InheritedWidget` reads and makes the logic hard to test. The
+rule flags both passing a `BuildContext` into a Bloc/Cubit (via a method such as
+`add`, or a constructor) and declaring one inside a Bloc/Cubit (as a parameter or
+field). A value merely derived from a context (e.g. `MediaQuery.sizeOf(context)`)
+is allowed.
+
+**BAD:**
+
+```dart
+bloc.add(CounterEvent(context));
+
+final event = CounterEvent(context);
+bloc.add(event);
+
+class CounterCubit extends Cubit<int> {
+  CounterCubit() : super(0);
+
+  final BuildContext context;
+
+  void another(BuildContext context) {}
+}
+```
+
+**GOOD:**
+
+```dart
+bloc.add(CounterEvent());
+bloc.add(CounterEvent(MediaQuery.sizeOf(context)));
+
+class CounterCubit extends Cubit<int> {
+  CounterCubit() : super(0);
+
+  void another() {}
+}
+```
+
+#### Configuration
+
+None.
+
+</details>
+
+<details>
 <summary><code>avoid_catch_error</code></summary>
 
 ### `avoid_catch_error`

--- a/packages/leancode_lint/lib/plugin.dart
+++ b/packages/leancode_lint/lib/plugin.dart
@@ -5,6 +5,7 @@ import 'package:leancode_lint/src/assists/convert_iterable_map_to_collection_for
 import 'package:leancode_lint/src/assists/convert_positional_to_named_formal.dart';
 import 'package:leancode_lint/src/assists/convert_record_into_nominal_type.dart';
 import 'package:leancode_lint/src/lints/add_cubit_suffix_for_cubits.dart';
+import 'package:leancode_lint/src/lints/avoid_build_context_in_blocs.dart';
 import 'package:leancode_lint/src/lints/avoid_catch_error.dart';
 import 'package:leancode_lint/src/lints/avoid_conditional_hooks.dart';
 import 'package:leancode_lint/src/lints/avoid_single_child_in_multi_child_widget.dart';
@@ -63,6 +64,7 @@ final class LeanCodeLintPlugin extends Plugin {
         CatchParameterNames(config: config.catchParameterNames),
       )
       ..registerWarningRule(AvoidCatchError())
+      ..registerWarningRule(AvoidBuildContextInBlocs())
       ..registerWarningRule(AvoidConditionalHooks())
       ..registerWarningRule(HookWidgetDoesNotUseHooks())
       ..registerFixForRule(

--- a/packages/leancode_lint/lib/src/lints/avoid_build_context_in_blocs.dart
+++ b/packages/leancode_lint/lib/src/lints/avoid_build_context_in_blocs.dart
@@ -1,0 +1,231 @@
+import 'package:analyzer/analysis_rule/analysis_rule.dart';
+import 'package:analyzer/analysis_rule/rule_context.dart';
+import 'package:analyzer/analysis_rule/rule_visitor_registry.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/type.dart';
+import 'package:analyzer/error/error.dart';
+import 'package:leancode_lint/src/bloc_utils.dart';
+import 'package:leancode_lint/src/type_checker.dart';
+
+/// Warns when a `BuildContext` crosses into a Bloc/Cubit.
+///
+/// A `BuildContext` couples business logic to the widget tree, which risks
+/// stale contexts and wrong `InheritedWidget` reads and makes the logic hard to
+/// test. This rule flags a `BuildContext` on both sides of the boundary:
+/// passing one into a Bloc/Cubit (via a method, e.g. `bloc.add(...)`, or a
+/// constructor) and declaring one inside a Bloc/Cubit (as a parameter or field).
+class AvoidBuildContextInBlocs extends AnalysisRule {
+  AvoidBuildContextInBlocs()
+    : super(name: code.lowerCaseName, description: code.problemMessage);
+
+  static const code = LintCode(
+    'avoid_build_context_in_blocs',
+    // The specific clause is supplied per report site via `arguments`.
+    '{0}',
+    correctionMessage:
+        "Business logic shouldn't depend on the widget tree. Pass only the data the Bloc/Cubit needs.",
+    severity: .WARNING,
+  );
+
+  @override
+  LintCode get diagnosticCode => code;
+
+  @override
+  void registerNodeProcessors(
+    RuleVisitorRegistry registry,
+    RuleContext context,
+  ) {
+    final visitor = _Visitor(this);
+    registry
+      ..addMethodInvocation(this, visitor)
+      ..addInstanceCreationExpression(this, visitor)
+      ..addClassDeclaration(this, visitor);
+  }
+}
+
+const _passingMessage = "Avoid passing 'BuildContext' to blocs.";
+
+String _parameterMessage(BlocType type) => switch (type) {
+  .bloc => "Avoid declaring 'BuildContext' parameters for Blocs.",
+  .cubit => "Avoid declaring 'BuildContext' parameters for Cubits.",
+};
+
+String _fieldMessage(BlocType type) => switch (type) {
+  .bloc => "Avoid declaring 'BuildContext' fields in Blocs.",
+  .cubit => "Avoid declaring 'BuildContext' fields in Cubits.",
+};
+
+class _Visitor extends SimpleAstVisitor<void> {
+  _Visitor(this.rule);
+
+  final AnalysisRule rule;
+
+  static const _buildContextChecker = TypeChecker.fromName(
+    'BuildContext',
+    packageName: 'flutter',
+  );
+
+  // Passing side: `bloc.add(...)` and other method calls on a Bloc/Cubit.
+  @override
+  void visitMethodInvocation(MethodInvocation node) {
+    final targetType = node.realTarget?.staticType;
+    if (targetType == null || determineBlocType(targetType.element) == null) {
+      return;
+    }
+
+    _reportContextArguments(node.argumentList);
+  }
+
+  // Passing side: `CounterCubit(context)` / `CounterBloc(context)`.
+  @override
+  void visitInstanceCreationExpression(InstanceCreationExpression node) {
+    if (determineBlocType(node.staticType?.element) == null) {
+      return;
+    }
+
+    _reportContextArguments(node.argumentList);
+  }
+
+  // Declaration side: `BuildContext` parameters and fields inside a Bloc/Cubit.
+  @override
+  void visitClassDeclaration(ClassDeclaration node) {
+    final element = node.declaredFragment?.element;
+    final blocType = determineBlocType(element);
+    if (blocType == null) {
+      return;
+    }
+
+    final members = switch (node.body) {
+      BlockClassBody(:final members) => members,
+      _ => const <ClassMember>[],
+    };
+
+    for (final member in members) {
+      switch (member) {
+        case MethodDeclaration(:final parameters?):
+          _checkParameters(parameters, blocType);
+        case ConstructorDeclaration(:final parameters):
+          _checkParameters(parameters, blocType);
+        case FieldDeclaration(:final fields):
+          _checkFields(fields, blocType);
+        case _:
+          break;
+      }
+    }
+  }
+
+  void _checkParameters(FormalParameterList parameters, BlocType blocType) {
+    for (final parameter in parameters.parameters) {
+      final name = parameter.name;
+      final type = parameter.declaredFragment?.element.type;
+      if (name != null && type != null && _isBuildContext(type)) {
+        rule.reportAtToken(name, arguments: [_parameterMessage(blocType)]);
+      }
+    }
+  }
+
+  void _checkFields(VariableDeclarationList fields, BlocType blocType) {
+    for (final variable in fields.variables) {
+      final type = variable.declaredFragment?.element.type;
+      if (type != null && _isBuildContext(type)) {
+        rule.reportAtToken(variable.name, arguments: [_fieldMessage(blocType)]);
+      }
+    }
+  }
+
+  void _reportContextArguments(ArgumentList argumentList) {
+    for (final argument in argumentList.arguments) {
+      final expression = argument.argumentExpression;
+      if (_carriesContext(expression, {}, 0)) {
+        rule.reportAtNode(expression, arguments: [_passingMessage]);
+      }
+    }
+  }
+
+  /// Whether [expression] carries a `BuildContext` into the enclosing call.
+  ///
+  /// Returns true when the expression is itself a `BuildContext`, when it
+  /// constructs an object with a `BuildContext` argument (e.g. an event like
+  /// `CounterEvent(context)`, including nested constructions), or when it is a
+  /// local variable whose initializer does so. Recursion deliberately does not
+  /// descend into method/function calls, so a value merely *derived* from a
+  /// context (e.g. `MediaQuery.sizeOf(context)`) is not flagged.
+  ///
+  /// The local-variable trace is best-effort: it only inspects the declaration
+  /// initializer, not later reassignments. [visited] guards against cycles.
+  bool _carriesContext(
+    Expression? expression,
+    Set<Element> visited,
+    int depth,
+  ) {
+    if (expression == null || depth > 20) {
+      return false;
+    }
+
+    final type = expression.staticType;
+    if (type != null && _isBuildContext(type)) {
+      return true;
+    }
+
+    switch (expression) {
+      case InstanceCreationExpression(:final argumentList):
+        for (final argument in argumentList.arguments) {
+          if (_carriesContext(
+            argument.argumentExpression,
+            visited,
+            depth + 1,
+          )) {
+            return true;
+          }
+        }
+      case SimpleIdentifier(:final Element element?)
+          when element is LocalVariableElement && visited.add(element):
+        final initializer = _localVariableInitializer(expression, element);
+        if (_carriesContext(initializer, visited, depth + 1)) {
+          return true;
+        }
+    }
+
+    return false;
+  }
+
+  Expression? _localVariableInitializer(
+    AstNode reference,
+    LocalVariableElement element,
+  ) {
+    AstNode? body = reference;
+    while (body != null && body is! FunctionBody) {
+      body = body.parent;
+    }
+    if (body == null) {
+      return null;
+    }
+
+    final finder = _InitializerFinder(element);
+    body.accept(finder);
+    return finder.initializer;
+  }
+
+  bool _isBuildContext(DartType type) =>
+      _buildContextChecker.isExactlyType(type);
+}
+
+/// Finds the declaration initializer of a specific [LocalVariableElement].
+class _InitializerFinder extends RecursiveAstVisitor<void> {
+  _InitializerFinder(this.element);
+
+  final LocalVariableElement element;
+  Expression? initializer;
+
+  @override
+  void visitVariableDeclaration(VariableDeclaration node) {
+    if (initializer == null &&
+        node.declaredFragment?.element == element &&
+        node.initializer != null) {
+      initializer = node.initializer;
+    }
+    super.visitVariableDeclaration(node);
+  }
+}

--- a/packages/leancode_lint/lib/src/lints/avoid_build_context_in_blocs.dart
+++ b/packages/leancode_lint/lib/src/lints/avoid_build_context_in_blocs.dart
@@ -112,7 +112,7 @@ class _Visitor extends SimpleAstVisitor<void> {
       ) when _isBuildContext(fragment.element.type)) {
         rule.reportAtToken(
           name,
-          arguments: ['declaring', 'parameter in', _blocTypeName(blocType)],
+          arguments: ['declaring', 'parameter in', blocType.name],
         );
       }
     }
@@ -124,7 +124,7 @@ class _Visitor extends SimpleAstVisitor<void> {
       if (type != null && _isBuildContext(type)) {
         rule.reportAtToken(
           variable.name,
-          arguments: ['declaring', 'field in', _blocTypeName(blocType)],
+          arguments: ['declaring', 'field in', blocType.name],
         );
       }
     }
@@ -136,7 +136,7 @@ class _Visitor extends SimpleAstVisitor<void> {
       if (_carriesContext(expression, {}, 0)) {
         rule.reportAtNode(
           expression,
-          arguments: ['passing', 'to', _blocTypeName(blocType)],
+          arguments: ['passing', 'to', blocType.name],
         );
       }
     }
@@ -214,11 +214,6 @@ class _Visitor extends SimpleAstVisitor<void> {
   bool _isBuildContext(DartType type) =>
       _buildContextChecker.isExactlyType(type);
 }
-
-String _blocTypeName(BlocType type) => switch (type) {
-  .bloc => 'Bloc',
-  .cubit => 'Cubit',
-};
 
 /// Finds the declaration initializer of a specific [LocalVariableElement].
 class _InitializerFinder extends GeneralizingAstVisitor<void> {

--- a/packages/leancode_lint/lib/src/lints/avoid_build_context_in_blocs.dart
+++ b/packages/leancode_lint/lib/src/lints/avoid_build_context_in_blocs.dart
@@ -18,17 +18,13 @@ import 'package:leancode_lint/src/type_checker.dart';
 /// constructor) and declaring one inside a Bloc/Cubit (as a parameter or field).
 class AvoidBuildContextInBlocs extends AnalysisRule {
   AvoidBuildContextInBlocs()
-    : super(
-        name: code.lowerCaseName,
-        description: "Avoid letting a 'BuildContext' cross into a Bloc/Cubit.",
-      );
+    : super(name: code.lowerCaseName, description: code.problemMessage);
 
   static const code = LintCode(
     'avoid_build_context_in_blocs',
-    // The specific clause is supplied per report site via `arguments`.
-    '{0}',
+    "Avoid using 'BuildContext' in a Bloc/Cubit.",
     correctionMessage:
-        "Business logic shouldn't depend on the widget tree. Pass only the data the Bloc/Cubit needs.",
+        "Remove the 'BuildContext' and directly pass only the data the Bloc/Cubit needs instead.",
     severity: .WARNING,
   );
 
@@ -47,18 +43,6 @@ class AvoidBuildContextInBlocs extends AnalysisRule {
       ..addClassDeclaration(this, visitor);
   }
 }
-
-const _passingMessage = "Avoid passing 'BuildContext' to a Bloc/Cubit.";
-
-String _parameterMessage(BlocType type) => switch (type) {
-  .bloc => "Avoid declaring 'BuildContext' parameters for Blocs.",
-  .cubit => "Avoid declaring 'BuildContext' parameters for Cubits.",
-};
-
-String _fieldMessage(BlocType type) => switch (type) {
-  .bloc => "Avoid declaring 'BuildContext' fields in Blocs.",
-  .cubit => "Avoid declaring 'BuildContext' fields in Cubits.",
-};
 
 class _Visitor extends SimpleAstVisitor<void> {
   _Visitor(this.rule);
@@ -95,8 +79,7 @@ class _Visitor extends SimpleAstVisitor<void> {
   @override
   void visitClassDeclaration(ClassDeclaration node) {
     final element = node.declaredFragment?.element;
-    final blocType = determineBlocType(element);
-    if (blocType == null) {
+    if (determineBlocType(element) == null) {
       return;
     }
 
@@ -108,32 +91,32 @@ class _Visitor extends SimpleAstVisitor<void> {
     for (final member in members) {
       switch (member) {
         case MethodDeclaration(:final parameters?):
-          _checkParameters(parameters, blocType);
+          _checkParameters(parameters);
         case ConstructorDeclaration(:final parameters):
-          _checkParameters(parameters, blocType);
+          _checkParameters(parameters);
         case FieldDeclaration(:final fields):
-          _checkFields(fields, blocType);
+          _checkFields(fields);
         case _:
           break;
       }
     }
   }
 
-  void _checkParameters(FormalParameterList parameters, BlocType blocType) {
+  void _checkParameters(FormalParameterList parameters) {
     for (final parameter in parameters.parameters) {
       final name = parameter.name;
       final type = parameter.declaredFragment?.element.type;
       if (name != null && type != null && _isBuildContext(type)) {
-        rule.reportAtToken(name, arguments: [_parameterMessage(blocType)]);
+        rule.reportAtToken(name);
       }
     }
   }
 
-  void _checkFields(VariableDeclarationList fields, BlocType blocType) {
+  void _checkFields(VariableDeclarationList fields) {
     for (final variable in fields.variables) {
       final type = variable.declaredFragment?.element.type;
       if (type != null && _isBuildContext(type)) {
-        rule.reportAtToken(variable.name, arguments: [_fieldMessage(blocType)]);
+        rule.reportAtToken(variable.name);
       }
     }
   }
@@ -142,7 +125,7 @@ class _Visitor extends SimpleAstVisitor<void> {
     for (final argument in argumentList.arguments) {
       final expression = argument.argumentExpression;
       if (_carriesContext(expression, {}, 0)) {
-        rule.reportAtNode(expression, arguments: [_passingMessage]);
+        rule.reportAtNode(expression);
       }
     }
   }

--- a/packages/leancode_lint/lib/src/lints/avoid_build_context_in_blocs.dart
+++ b/packages/leancode_lint/lib/src/lints/avoid_build_context_in_blocs.dart
@@ -18,7 +18,10 @@ import 'package:leancode_lint/src/type_checker.dart';
 /// constructor) and declaring one inside a Bloc/Cubit (as a parameter or field).
 class AvoidBuildContextInBlocs extends AnalysisRule {
   AvoidBuildContextInBlocs()
-    : super(name: code.lowerCaseName, description: code.problemMessage);
+    : super(
+        name: code.lowerCaseName,
+        description: "Avoid letting a 'BuildContext' cross into a Bloc/Cubit.",
+      );
 
   static const code = LintCode(
     'avoid_build_context_in_blocs',
@@ -45,7 +48,7 @@ class AvoidBuildContextInBlocs extends AnalysisRule {
   }
 }
 
-const _passingMessage = "Avoid passing 'BuildContext' to blocs.";
+const _passingMessage = "Avoid passing 'BuildContext' to a Bloc/Cubit.";
 
 String _parameterMessage(BlocType type) => switch (type) {
   .bloc => "Avoid declaring 'BuildContext' parameters for Blocs.",

--- a/packages/leancode_lint/lib/src/lints/avoid_build_context_in_blocs.dart
+++ b/packages/leancode_lint/lib/src/lints/avoid_build_context_in_blocs.dart
@@ -2,6 +2,7 @@ import 'package:analyzer/analysis_rule/analysis_rule.dart';
 import 'package:analyzer/analysis_rule/rule_context.dart';
 import 'package:analyzer/analysis_rule/rule_visitor_registry.dart';
 import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/token.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
@@ -22,9 +23,9 @@ class AvoidBuildContextInBlocs extends AnalysisRule {
 
   static const code = LintCode(
     'avoid_build_context_in_blocs',
-    "Avoid using 'BuildContext' in a Bloc/Cubit.",
+    "Avoid {0} a 'BuildContext' {1} a {2}.",
     correctionMessage:
-        "Remove the 'BuildContext' and directly pass only the data the Bloc/Cubit needs instead.",
+        "Remove the 'BuildContext' and pass only the data the {2} needs.",
     severity: .WARNING,
   );
 
@@ -57,29 +58,30 @@ class _Visitor extends SimpleAstVisitor<void> {
   // Passing side: `bloc.add(...)` and other method calls on a Bloc/Cubit.
   @override
   void visitMethodInvocation(MethodInvocation node) {
-    final targetType = node.realTarget?.staticType;
-    if (targetType == null || determineBlocType(targetType.element) == null) {
+    final blocType = determineBlocType(node.realTarget?.staticType?.element);
+    if (blocType == null) {
       return;
     }
 
-    _reportContextArguments(node.argumentList);
+    _reportContextArguments(node.argumentList, blocType);
   }
 
   // Passing side: `CounterCubit(context)` / `CounterBloc(context)`.
   @override
   void visitInstanceCreationExpression(InstanceCreationExpression node) {
-    if (determineBlocType(node.staticType?.element) == null) {
+    final blocType = determineBlocType(node.staticType?.element);
+    if (blocType == null) {
       return;
     }
 
-    _reportContextArguments(node.argumentList);
+    _reportContextArguments(node.argumentList, blocType);
   }
 
   // Declaration side: `BuildContext` parameters and fields inside a Bloc/Cubit.
   @override
   void visitClassDeclaration(ClassDeclaration node) {
-    final element = node.declaredFragment?.element;
-    if (determineBlocType(element) == null) {
+    final blocType = determineBlocType(node.declaredFragment?.element);
+    if (blocType == null) {
       return;
     }
 
@@ -91,41 +93,51 @@ class _Visitor extends SimpleAstVisitor<void> {
     for (final member in members) {
       switch (member) {
         case MethodDeclaration(:final parameters?):
-          _checkParameters(parameters);
+          _checkParameters(parameters, blocType);
         case ConstructorDeclaration(:final parameters):
-          _checkParameters(parameters);
+          _checkParameters(parameters, blocType);
         case FieldDeclaration(:final fields):
-          _checkFields(fields);
+          _checkFields(fields, blocType);
         case _:
           break;
       }
     }
   }
 
-  void _checkParameters(FormalParameterList parameters) {
+  void _checkParameters(FormalParameterList parameters, BlocType blocType) {
     for (final parameter in parameters.parameters) {
-      final name = parameter.name;
-      final type = parameter.declaredFragment?.element.type;
-      if (name != null && type != null && _isBuildContext(type)) {
-        rule.reportAtToken(name);
+      if (parameter case FormalParameter(
+        :final name?,
+        declaredFragment: final fragment?,
+      ) when _isBuildContext(fragment.element.type)) {
+        rule.reportAtToken(
+          name,
+          arguments: ['declaring', 'parameter in', _blocTypeName(blocType)],
+        );
       }
     }
   }
 
-  void _checkFields(VariableDeclarationList fields) {
+  void _checkFields(VariableDeclarationList fields, BlocType blocType) {
     for (final variable in fields.variables) {
       final type = variable.declaredFragment?.element.type;
       if (type != null && _isBuildContext(type)) {
-        rule.reportAtToken(variable.name);
+        rule.reportAtToken(
+          variable.name,
+          arguments: ['declaring', 'field in', _blocTypeName(blocType)],
+        );
       }
     }
   }
 
-  void _reportContextArguments(ArgumentList argumentList) {
+  void _reportContextArguments(ArgumentList argumentList, BlocType blocType) {
     for (final argument in argumentList.arguments) {
       final expression = argument.argumentExpression;
       if (_carriesContext(expression, {}, 0)) {
-        rule.reportAtNode(expression);
+        rule.reportAtNode(
+          expression,
+          arguments: ['passing', 'to', _blocTypeName(blocType)],
+        );
       }
     }
   }
@@ -150,8 +162,7 @@ class _Visitor extends SimpleAstVisitor<void> {
       return false;
     }
 
-    final type = expression.staticType;
-    if (type != null && _isBuildContext(type)) {
+    if (expression.staticType case final type? when _isBuildContext(type)) {
       return true;
     }
 
@@ -166,8 +177,14 @@ class _Visitor extends SimpleAstVisitor<void> {
             return true;
           }
         }
-      case SimpleIdentifier(:final Element element?)
-          when element is LocalVariableElement && visited.add(element):
+      case ParenthesizedExpression(:final expression):
+      case AsExpression(:final expression):
+        return _carriesContext(expression, visited, depth + 1);
+      case PostfixExpression(:final operand, :final operator)
+          when operator.type == TokenType.BANG:
+        return _carriesContext(operand, visited, depth + 1);
+      case SimpleIdentifier(:final LocalVariableElement element?)
+          when visited.add(element):
         final initializer = _localVariableInitializer(expression, element);
         if (_carriesContext(initializer, visited, depth + 1)) {
           return true;
@@ -198,12 +215,24 @@ class _Visitor extends SimpleAstVisitor<void> {
       _buildContextChecker.isExactlyType(type);
 }
 
+String _blocTypeName(BlocType type) => switch (type) {
+  .bloc => 'Bloc',
+  .cubit => 'Cubit',
+};
+
 /// Finds the declaration initializer of a specific [LocalVariableElement].
-class _InitializerFinder extends RecursiveAstVisitor<void> {
+class _InitializerFinder extends GeneralizingAstVisitor<void> {
   _InitializerFinder(this.element);
 
   final LocalVariableElement element;
   Expression? initializer;
+
+  @override
+  void visitNode(AstNode node) {
+    if (initializer == null) {
+      super.visitNode(node);
+    }
+  }
 
   @override
   void visitVariableDeclaration(VariableDeclaration node) {

--- a/packages/leancode_lint/test/mock_libraries/bloc.dart
+++ b/packages/leancode_lint/test/mock_libraries/bloc.dart
@@ -15,6 +15,7 @@ abstract class Cubit<State> extends BlocBase<State> {
 
 abstract class Bloc<Event, State> extends BlocBase<State> {
   Bloc(State initialState) : super(initialState);
+  void add(Event event) {}
 }
 ''');
     super.setUp();

--- a/packages/leancode_lint/test/test_cases/avoid_build_context_in_blocs_test.dart
+++ b/packages/leancode_lint/test/test_cases/avoid_build_context_in_blocs_test.dart
@@ -59,9 +59,9 @@ void f(CounterBloc bloc, BuildContext context) {
       lint(
         code.lastIndexOf('context'),
         'context'.length,
-        messageContainsAll: ["Avoid passing a 'BuildContext' to a Bloc."],
+        messageContainsAll: ["Avoid passing a 'BuildContext' to a bloc."],
         correctionContains:
-            "Remove the 'BuildContext' and pass only the data the Bloc needs.",
+            "Remove the 'BuildContext' and pass only the data the bloc needs.",
       ),
     ]);
   }
@@ -130,9 +130,9 @@ void f(BuildContext context) {
       lint(
         code.lastIndexOf('context'),
         'context'.length,
-        messageContainsAll: ["Avoid passing a 'BuildContext' to a Cubit."],
+        messageContainsAll: ["Avoid passing a 'BuildContext' to a cubit."],
         correctionContains:
-            "Remove the 'BuildContext' and pass only the data the Cubit needs.",
+            "Remove the 'BuildContext' and pass only the data the cubit needs.",
       ),
     ]);
   }
@@ -154,7 +154,7 @@ class CounterCubit extends Cubit<int> {
         code.lastIndexOf('context'),
         'context'.length,
         messageContainsAll: [
-          "Avoid declaring a 'BuildContext' parameter in a Cubit.",
+          "Avoid declaring a 'BuildContext' parameter in a cubit.",
         ],
       ),
     ]);
@@ -218,7 +218,7 @@ class CounterCubit extends Cubit<int> {
         code.lastIndexOf('context'),
         'context'.length,
         messageContainsAll: [
-          "Avoid declaring a 'BuildContext' field in a Cubit.",
+          "Avoid declaring a 'BuildContext' field in a cubit.",
         ],
       ),
     ]);

--- a/packages/leancode_lint/test/test_cases/avoid_build_context_in_blocs_test.dart
+++ b/packages/leancode_lint/test/test_cases/avoid_build_context_in_blocs_test.dart
@@ -42,7 +42,7 @@ void f(CounterBloc bloc, BuildContext context) {
   }
 
   Future<void> test_passingContextDirectly_flagged() async {
-    await assertDiagnosticsInRanges('''
+    const code = '''
 import 'package:flutter/material.dart';
 import 'package:bloc/bloc.dart';
 
@@ -51,9 +51,19 @@ class CounterBloc extends Bloc<Object, int> {
 }
 
 void f(CounterBloc bloc, BuildContext context) {
-  bloc.add([!context!]);
+  bloc.add(context);
 }
-''');
+''';
+
+    await assertDiagnostics(code, [
+      lint(
+        code.lastIndexOf('context'),
+        'context'.length,
+        messageContainsAll: ["Avoid passing a 'BuildContext' to a Bloc."],
+        correctionContains:
+            "Remove the 'BuildContext' and pass only the data the Bloc needs.",
+      ),
+    ]);
   }
 
   Future<void> test_passingContextViaLocalVariable_flagged() async {
@@ -103,7 +113,7 @@ void f(CounterBloc bloc, BuildContext context) {
   }
 
   Future<void> test_passingContextToConstructor_flagged() async {
-    await assertDiagnosticsInRanges('''
+    const code = '''
 import 'package:flutter/material.dart';
 import 'package:bloc/bloc.dart';
 
@@ -112,22 +122,42 @@ class CounterCubit extends Cubit<int> {
 }
 
 void f(BuildContext context) {
-  CounterCubit([!context!]);
+  CounterCubit(context);
 }
-''');
+''';
+
+    await assertDiagnostics(code, [
+      lint(
+        code.lastIndexOf('context'),
+        'context'.length,
+        messageContainsAll: ["Avoid passing a 'BuildContext' to a Cubit."],
+        correctionContains:
+            "Remove the 'BuildContext' and pass only the data the Cubit needs.",
+      ),
+    ]);
   }
 
   Future<void> test_cubitMethodParameter_flagged() async {
-    await assertDiagnosticsInRanges('''
+    const code = '''
 import 'package:flutter/material.dart';
 import 'package:bloc/bloc.dart';
 
 class CounterCubit extends Cubit<int> {
   CounterCubit() : super(0);
 
-  void another(BuildContext [!context!]) {}
+  void another(BuildContext context) {}
 }
-''');
+''';
+
+    await assertDiagnostics(code, [
+      lint(
+        code.lastIndexOf('context'),
+        'context'.length,
+        messageContainsAll: [
+          "Avoid declaring a 'BuildContext' parameter in a Cubit.",
+        ],
+      ),
+    ]);
   }
 
   Future<void> test_blocMethodParameter_flagged() async {
@@ -172,14 +202,87 @@ class CounterCubit extends Cubit<int> {
   }
 
   Future<void> test_cubitField_flagged() async {
-    await assertDiagnosticsInRanges('''
+    const code = '''
 import 'package:flutter/material.dart';
 import 'package:bloc/bloc.dart';
 
 class CounterCubit extends Cubit<int> {
   CounterCubit() : super(0);
 
-  late final BuildContext [!context!];
+  late final BuildContext context;
+}
+''';
+
+    await assertDiagnostics(code, [
+      lint(
+        code.lastIndexOf('context'),
+        'context'.length,
+        messageContainsAll: [
+          "Avoid declaring a 'BuildContext' field in a Cubit.",
+        ],
+      ),
+    ]);
+  }
+
+  Future<void> test_passingParenthesizedLocalVariable_flagged() async {
+    await assertDiagnosticsInRanges('''
+import 'package:flutter/material.dart';
+import 'package:bloc/bloc.dart';
+
+class CounterEvent {
+  CounterEvent(this.context);
+  final BuildContext context;
+}
+
+class CounterBloc extends Bloc<Object, int> {
+  CounterBloc() : super(0);
+}
+
+void f(CounterBloc bloc, BuildContext context) {
+  final event = CounterEvent(context);
+  bloc.add([!(event)!]);
+}
+''');
+  }
+
+  Future<void> test_passingCastLocalVariable_flagged() async {
+    await assertDiagnosticsInRanges('''
+import 'package:flutter/material.dart';
+import 'package:bloc/bloc.dart';
+
+class CounterEvent {
+  CounterEvent(this.context);
+  final BuildContext context;
+}
+
+class CounterBloc extends Bloc<Object, int> {
+  CounterBloc() : super(0);
+}
+
+void f(CounterBloc bloc, BuildContext context) {
+  final event = CounterEvent(context);
+  bloc.add([!event as Object!]);
+}
+''');
+  }
+
+  Future<void> test_passingNullAssertedLocalVariable_flagged() async {
+    await assertDiagnosticsInRanges('''
+import 'package:flutter/material.dart';
+import 'package:bloc/bloc.dart';
+
+class CounterEvent {
+  CounterEvent(this.context);
+  final BuildContext context;
+}
+
+class CounterBloc extends Bloc<Object, int> {
+  CounterBloc() : super(0);
+}
+
+void f(CounterBloc bloc, BuildContext context) {
+  final CounterEvent? event = CounterEvent(context) as dynamic;
+  bloc.add(/*[0*/event!/*0]*/);
 }
 ''');
   }

--- a/packages/leancode_lint/test/test_cases/avoid_build_context_in_blocs_test.dart
+++ b/packages/leancode_lint/test/test_cases/avoid_build_context_in_blocs_test.dart
@@ -1,0 +1,255 @@
+import 'package:analyzer_testing/analysis_rule/analysis_rule.dart';
+import 'package:leancode_lint/src/lints/avoid_build_context_in_blocs.dart';
+import 'package:test_reflective_loader/test_reflective_loader.dart';
+
+import '../assert_ranges.dart';
+import '../mock_libraries.dart';
+
+void main() {
+  defineReflectiveSuite(() {
+    defineReflectiveTests(AvoidBuildContextInBlocsTest);
+  });
+}
+
+@reflectiveTest
+class AvoidBuildContextInBlocsTest extends AnalysisRuleTest
+    with MockBloc, MockFlutter {
+  @override
+  void setUp() {
+    rule = AvoidBuildContextInBlocs();
+
+    super.setUp();
+  }
+
+  Future<void> test_passingContextInEvent_flagged() async {
+    await assertDiagnosticsInRanges('''
+import 'package:flutter/material.dart';
+import 'package:bloc/bloc.dart';
+
+class CounterEvent {
+  CounterEvent([this.data]);
+  final Object? data;
+}
+
+class CounterBloc extends Bloc<CounterEvent, int> {
+  CounterBloc() : super(0);
+}
+
+void f(CounterBloc bloc, BuildContext context) {
+  bloc.add([!CounterEvent(context)!]);
+}
+''');
+  }
+
+  Future<void> test_passingContextDirectly_flagged() async {
+    await assertDiagnosticsInRanges('''
+import 'package:flutter/material.dart';
+import 'package:bloc/bloc.dart';
+
+class CounterBloc extends Bloc<Object, int> {
+  CounterBloc() : super(0);
+}
+
+void f(CounterBloc bloc, BuildContext context) {
+  bloc.add([!context!]);
+}
+''');
+  }
+
+  Future<void> test_passingContextViaLocalVariable_flagged() async {
+    await assertDiagnosticsInRanges('''
+import 'package:flutter/material.dart';
+import 'package:bloc/bloc.dart';
+
+class CounterEvent {
+  CounterEvent([this.data]);
+  final Object? data;
+}
+
+class CounterBloc extends Bloc<CounterEvent, int> {
+  CounterBloc() : super(0);
+}
+
+void f(CounterBloc bloc, BuildContext context) {
+  final event = CounterEvent(context);
+  bloc.add([!event!]);
+}
+''');
+  }
+
+  Future<void> test_passingContextInNestedEvent_flagged() async {
+    await assertDiagnosticsInRanges('''
+import 'package:flutter/material.dart';
+import 'package:bloc/bloc.dart';
+
+class Inner {
+  Inner(this.context);
+  final BuildContext context;
+}
+
+class CounterEvent {
+  CounterEvent(this.inner);
+  final Inner inner;
+}
+
+class CounterBloc extends Bloc<CounterEvent, int> {
+  CounterBloc() : super(0);
+}
+
+void f(CounterBloc bloc, BuildContext context) {
+  bloc.add([!CounterEvent(Inner(context))!]);
+}
+''');
+  }
+
+  Future<void> test_passingContextToConstructor_flagged() async {
+    await assertDiagnosticsInRanges('''
+import 'package:flutter/material.dart';
+import 'package:bloc/bloc.dart';
+
+class CounterCubit extends Cubit<int> {
+  CounterCubit(Object data) : super(0);
+}
+
+void f(BuildContext context) {
+  CounterCubit([!context!]);
+}
+''');
+  }
+
+  Future<void> test_cubitMethodParameter_flagged() async {
+    await assertDiagnosticsInRanges('''
+import 'package:flutter/material.dart';
+import 'package:bloc/bloc.dart';
+
+class CounterCubit extends Cubit<int> {
+  CounterCubit() : super(0);
+
+  void another(BuildContext [!context!]) {}
+}
+''');
+  }
+
+  Future<void> test_blocMethodParameter_flagged() async {
+    await assertDiagnosticsInRanges('''
+import 'package:flutter/material.dart';
+import 'package:bloc/bloc.dart';
+
+class CounterBloc extends Bloc<Object, int> {
+  CounterBloc() : super(0);
+
+  void another(BuildContext [!context!]) {}
+}
+''');
+  }
+
+  Future<void> test_passingContextToCustomBlocMethod_flagged() async {
+    await assertDiagnosticsInRanges('''
+import 'package:flutter/material.dart';
+import 'package:bloc/bloc.dart';
+
+class CounterBloc extends Bloc<Object, int> {
+  CounterBloc() : super(0);
+
+  void doSomething(BuildContext /*[0*/context/*0]*/) {}
+}
+
+void f(CounterBloc bloc, BuildContext context) {
+  bloc.doSomething(/*[1*/context/*1]*/);
+}
+''');
+  }
+
+  Future<void> test_cubitConstructorParameter_flagged() async {
+    await assertDiagnosticsInRanges('''
+import 'package:flutter/material.dart';
+import 'package:bloc/bloc.dart';
+
+class CounterCubit extends Cubit<int> {
+  CounterCubit(BuildContext [!context!]) : super(0);
+}
+''');
+  }
+
+  Future<void> test_cubitField_flagged() async {
+    await assertDiagnosticsInRanges('''
+import 'package:flutter/material.dart';
+import 'package:bloc/bloc.dart';
+
+class CounterCubit extends Cubit<int> {
+  CounterCubit() : super(0);
+
+  late final BuildContext [!context!];
+}
+''');
+  }
+
+  Future<void> test_addWithoutContext_ok() async {
+    await assertNoDiagnostics('''
+import 'package:bloc/bloc.dart';
+
+class CounterEvent {
+  CounterEvent();
+}
+
+class CounterBloc extends Bloc<CounterEvent, int> {
+  CounterBloc() : super(0);
+}
+
+void f(CounterBloc bloc) {
+  bloc.add(CounterEvent());
+}
+''');
+  }
+
+  Future<void> test_passingContextDerivedValue_ok() async {
+    await assertNoDiagnostics('''
+import 'package:flutter/material.dart';
+import 'package:bloc/bloc.dart';
+
+int deriveFrom(BuildContext context) => 0;
+
+class CounterEvent {
+  CounterEvent(this.data);
+  final int data;
+}
+
+class CounterBloc extends Bloc<CounterEvent, int> {
+  CounterBloc() : super(0);
+}
+
+void f(CounterBloc bloc, BuildContext context) {
+  bloc.add(CounterEvent(deriveFrom(context)));
+}
+''');
+  }
+
+  Future<void> test_contextParameterOnNonBloc_ok() async {
+    await assertNoDiagnostics('''
+import 'package:flutter/material.dart';
+
+class NotABloc {
+  void another(BuildContext context) {}
+}
+''');
+  }
+
+  Future<void> test_methodCallOnNonBloc_ok() async {
+    await assertNoDiagnostics('''
+import 'package:flutter/material.dart';
+
+class NotABloc {
+  void add(Object event) {}
+}
+
+class CounterEvent {
+  CounterEvent(this.context);
+  final BuildContext context;
+}
+
+void f(NotABloc notABloc, BuildContext context) {
+  notABloc.add(CounterEvent(context));
+}
+''');
+  }
+}


### PR DESCRIPTION
Adds a warning-level lint that flags `BuildContext` crossing into a Bloc/Cubit — either passed in (via a method like `add`, or a constructor) or declared inside one (parameter or field).
