### PR TITLE
leancode_force_update: upgrade contracts deps and regenerate

### DIFF
--- a/packages/leancode_force_update/.config/dotnet-tools.json
+++ b/packages/leancode_force_update/.config/dotnet-tools.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "dotnet-contracts-generate": {
+      "version": "4.0.0",
+      "commands": [
+        "dotnet-contracts-generate"
+      ],
+      "rollForward": false
+    }
+  }
+}

--- a/packages/leancode_force_update/CHANGELOG.md
+++ b/packages/leancode_force_update/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.0.3-alpha
+
+- Upgrade `leancode_contracts` dependency to `^0.9.0`
+- Upgrade `leancode_contracts_generator` dev dependency to `^0.18.0`
+- Upgrade `Leancode.ForceUpdate.Contracts` to `10.0.2860`
+- Regenerate contracts
+
 ## 1.0.2-alpha
 
 - Upgrade `package_info_plus` dependency to `^10.2.0`

--- a/packages/leancode_force_update/README.md
+++ b/packages/leancode_force_update/README.md
@@ -27,6 +27,15 @@ For a complete working sample, see [example](example).
 
 Android has an API for performing updates within the app, without necessity of opening Play Store. To use the API, set `useAndroidSystemUI` to true in in the constructor of `ForceUpdateGuard`.
 
+## Regenerating contracts
+
+The contracts in [lib/data/contracts](lib/data/contracts) are generated from the `Leancode.ForceUpdate.Contracts` NuGet package referenced by [backend.csproj](lib/data/contracts/source/backend.csproj). Regenerating them requires the .NET SDK, since `leancode_contracts_generator` delegates to the .NET generator pinned in [.config/dotnet-tools.json](.config/dotnet-tools.json):
+
+```sh
+dart run leancode_contracts_generator
+dart run build_runner build
+```
+
 ---
 
 ## 🛠️ Maintained by LeanCode

--- a/packages/leancode_force_update/build.yaml
+++ b/packages/leancode_force_update/build.yaml
@@ -1,0 +1,9 @@
+targets:
+  $default:
+    # Limit the build to the generated contracts, so that neither the example app
+    # nor the rest of the library is needlessly analyzed by `json_serializable`.
+    sources:
+      - $package$
+      - lib/$lib$
+      - lib/data/contracts/contracts.dart
+      - pubspec.yaml

--- a/packages/leancode_force_update/example/pubspec.lock
+++ b/packages/leancode_force_update/example/pubspec.lock
@@ -173,10 +173,10 @@ packages:
     dependency: transitive
     description:
       name: equatable
-      sha256: "567c64b3cb4cf82397aac55f4f0cbd3ca20d77c6c03bedbc4ceaddc08904aef7"
+      sha256: "3bce007a596ff8b3119c45d68aaef631272537c03d30e5d4534dd24bf4c5eaa2"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.7"
+    version: "2.1.0"
   fake_async:
     dependency: transitive
     description:
@@ -316,10 +316,10 @@ packages:
     dependency: transitive
     description:
       name: leancode_contracts
-      sha256: bb41f0a00f3a97d227bd45be14d4a9286caa78b8a49f343ef5cd937f653345fd
+      sha256: "1acf05253c522134ddda25a46b31adaf4b5756714e97f5fff0e29437fd4dce87"
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.9.0"
   leancode_force_update:
     dependency: "direct main"
     description:

--- a/packages/leancode_force_update/lib/data/contracts/contracts.dart
+++ b/packages/leancode_force_update/lib/data/contracts/contracts.dart
@@ -11,7 +11,7 @@ enum PlatformDTO {
 }
 
 @ContractsSerializable()
-class VersionSupport with EquatableMixin implements Query<VersionSupportDTO> {
+class VersionSupport with Equatable implements Query<VersionSupportDTO> {
   VersionSupport({required this.platform, required this.version});
 
   factory VersionSupport.fromJson(Map<String, dynamic> json) =>
@@ -21,16 +21,20 @@ class VersionSupport with EquatableMixin implements Query<VersionSupportDTO> {
 
   final String version;
 
+  static const fullName$ = 'LeanCode.ForceUpdate.Contracts.VersionSupport';
+
   List<Object?> get props => [platform, version];
 
   Map<String, dynamic> toJson() => _$VersionSupportToJson(this);
+
   VersionSupportDTO resultFactory(dynamic decodedJson) =>
       _$VersionSupportDTOFromJson(decodedJson as Map<String, dynamic>);
-  String getFullName() => 'LeanCode.ForceUpdate.Contracts.VersionSupport';
+
+  String getFullName() => fullName$;
 }
 
 @ContractsSerializable()
-class VersionSupportDTO with EquatableMixin {
+class VersionSupportDTO with Equatable {
   VersionSupportDTO({
     required this.currentlySupportedVersion,
     required this.minimumRequiredVersion,
@@ -45,6 +49,8 @@ class VersionSupportDTO with EquatableMixin {
   final String minimumRequiredVersion;
 
   final VersionSupportResultDTO result;
+
+  static const fullName$ = 'LeanCode.ForceUpdate.Contracts.VersionSupportDTO';
 
   List<Object?> get props => [
     currentlySupportedVersion,
@@ -65,10 +71,12 @@ enum VersionSupportResultDTO {
 }
 
 @ContractsSerializable()
-class Class1 with EquatableMixin {
+class Class1 with Equatable {
   Class1();
 
   factory Class1.fromJson(Map<String, dynamic> json) => _$Class1FromJson(json);
+
+  static const fullName$ = 'backend.Class1';
 
   List<Object?> get props => [];
 

--- a/packages/leancode_force_update/lib/data/contracts/source/NuGet.config
+++ b/packages/leancode_force_update/lib/data/contracts/source/NuGet.config
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <add key="LeanCode Nightly Feed" value="https://f.feedz.io/leancode/public/nuget/index.json" />
-  </packageSources>
-</configuration>

--- a/packages/leancode_force_update/lib/data/contracts/source/backend.csproj
+++ b/packages/leancode_force_update/lib/data/contracts/source/backend.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Leancode.ForceUpdate.Contracts" Version="8.0.1996-preview" />
+    <PackageReference Include="Leancode.ForceUpdate.Contracts" Version="10.0.2860" />
   </ItemGroup>
 
 </Project>

--- a/packages/leancode_force_update/pubspec.yaml
+++ b/packages/leancode_force_update/pubspec.yaml
@@ -1,5 +1,5 @@
 name: leancode_force_update
-version: 1.0.2-alpha
+version: 1.0.3-alpha
 homepage: https://github.com/leancodepl/flutter_corelibrary/tree/master/packages/leancode_force_update
 repository: https://github.com/leancodepl/flutter_corelibrary
 description: An internal package that speeds up implementation of Force Update
@@ -13,7 +13,7 @@ dependencies:
   flutter:
     sdk: flutter
   in_app_update: ^4.2.3
-  leancode_contracts: ^0.8.0
+  leancode_contracts: ^0.9.0
   logging: ^1.3.0
   package_info_plus: ^10.2.0
   shared_preferences: ^2.5.3
@@ -21,8 +21,10 @@ dependencies:
   version: ^3.0.2
 
 dev_dependencies:
+  build_runner: ^2.7.1
   flutter_test:
     sdk: flutter
-  leancode_contracts_generator: ^0.14.0
+  json_serializable: ^6.11.2
+  leancode_contracts_generator: ^0.18.0
   leancode_lint: ^17.0.0
   mocktail: ^1.0.4


### PR DESCRIPTION
Upgrades the contracts runtime and generator dependencies of `leancode_force_update` and regenerates the contracts.

## Dart dependencies

- `leancode_contracts` `^0.8.0` → `^0.9.0`
- `leancode_contracts_generator` `^0.14.0` → `^0.18.0`
- added `build_runner: ^2.7.1` and `json_serializable: ^6.11.2` — generator `v0.17.0` stopped running `json_serializable` on its own
- version bumped to `1.0.3-alpha`, CHANGELOG updated

## New generator plumbing

- `.config/dotnet-tools.json` pinning `dotnet-contracts-generate` to `4.0.0`. Since generator `v0.15.0` the .NET generator is invoked as a `dotnet tool` and the manifest's presence is required for it to be found.
- `build.yaml` limiting the build to `lib/data/contracts/contracts.dart`. Without it `json_serializable` also crawls `example/` (including its `.dart_tool`), which fails the build.
- README gained a short "Regenerating contracts" section describing the now two-step flow.

## Regenerated contracts

`contracts.dart` now mixes in `Equatable` instead of the deprecated `EquatableMixin`, and each type exposes a `static const fullName$` that `getFullName()` returns. `contracts.g.dart` regenerated byte-identical. The contracts are not exported from `leancode_force_update.dart`, so this is internal.

## Heads-up: the .NET contracts package was bumped too

`Leancode.ForceUpdate.Contracts` went `8.0.1996-preview` → `10.0.2860`, and the nightly-feed `NuGet.config` next to `backend.csproj` was dropped since `10.0.2860` is a stable nuget.org release.

This wasn't strictly part of the dependency upgrade — the pinned preview build only exists on the LeanCode nightly feed, which is unreachable from the environment this was prepared in, so `dotnet restore` (and therefore regeneration) couldn't run against it. The type and member surface of both assemblies is identical (`VersionSupport`, `VersionSupportDTO`, `PlatformDTO`, `VersionSupportResultDTO`), and the regenerated JSON keys and enum values are unchanged, so nothing on the wire moves. It is still a two-major-version jump that may deserve a deliberate decision; reverting it means restoring `NuGet.config` as well.

## Note on `leancode_lint`

`leancode_lint` stays at `^17.0.0`, which pins `analyzer ^7.3.0`. That caps `json_serializable` at `6.11.2` and produces a `SDK language version is newer than analyzer language version` warning during the build. Moving to `^25.0.0` (the version this repo publishes) would clear it but requires raising the package's minimum SDK to `>=3.11.0`, so it was left out of this change.

## Verification

`dart run leancode_contracts_generator` → `dart run build_runner build` → `flutter analyze` (no issues) → `flutter test` (8/8 passing), on Flutter 3.44.8 / Dart 3.12.2 with .NET SDK 8.0.129.

---
_Generated by [Claude Code](https://claude.ai/code/session_017CcYWNv5ST2ps2y27WohyA)_