### PR TITLE
Add pana-score CI step to all package test workflows

### DIFF
--- a/.github/workflows/cqrs-test.yml
+++ b/.github/workflows/cqrs-test.yml
@@ -75,6 +75,6 @@ jobs:
       - name: Score with pana
         id: pana
         continue-on-error: true
-        uses: leancodepl/mobile-tools/.github/actions/pana-score@pana-score-v1
+        uses: leancodepl/mobile-tools/.github/actions/pana-score@68d925e42153f53e69d6c2501534f0c3c0a1a3be # v1.1
         with:
           path: packages/cqrs

--- a/.github/workflows/cqrs-test.yml
+++ b/.github/workflows/cqrs-test.yml
@@ -6,10 +6,12 @@ on:
     tags-ignore: ['cqrs-v*']
     paths:
       - 'packages/cqrs/**'
+      - '.github/workflows/cqrs-test.yml'
   pull_request:
     branches: [master]
     paths:
       - 'packages/cqrs/**'
+      - '.github/workflows/cqrs-test.yml'
 
 jobs:
   test:

--- a/.github/workflows/cqrs-test.yml
+++ b/.github/workflows/cqrs-test.yml
@@ -19,10 +19,6 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    permissions:
-      contents: read
-      statuses: write
-
     strategy:
       fail-fast: false
       matrix:
@@ -72,9 +68,20 @@ jobs:
         with:
           flags: cqrs
 
+  pana-score:
+    name: pana score
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      statuses: write
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+
       - name: Score with pana
-        id: pana
         continue-on-error: true
-        uses: leancodepl/mobile-tools/.github/actions/pana-score@68d925e42153f53e69d6c2501534f0c3c0a1a3be # v1.1
+        uses: leancodepl/mobile-tools/.github/actions/pana-score@e9f138c252f8e2254c88273367958fcc6bb39cad # pana-score-v1.3
         with:
           path: packages/cqrs

--- a/.github/workflows/cqrs-test.yml
+++ b/.github/workflows/cqrs-test.yml
@@ -16,6 +16,11 @@ jobs:
     name: Dart ${{ matrix.dart_release }}
 
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      statuses: write
+
     strategy:
       fail-fast: false
       matrix:
@@ -64,3 +69,10 @@ jobs:
       - uses: codecov/codecov-action@v1
         with:
           flags: cqrs
+
+      - name: Score with pana
+        id: pana
+        continue-on-error: true
+        uses: leancodepl/mobile-tools/.github/actions/pana-score@pana-score-v1
+        with:
+          path: packages/cqrs

--- a/.github/workflows/enhanced_gradients-test.yml
+++ b/.github/workflows/enhanced_gradients-test.yml
@@ -64,6 +64,6 @@ jobs:
       - name: Score with pana
         id: pana
         continue-on-error: true
-        uses: leancodepl/mobile-tools/.github/actions/pana-score@pana-score-v1
+        uses: leancodepl/mobile-tools/.github/actions/pana-score@68d925e42153f53e69d6c2501534f0c3c0a1a3be # v1.1
         with:
           path: packages/enhanced_gradients

--- a/.github/workflows/enhanced_gradients-test.yml
+++ b/.github/workflows/enhanced_gradients-test.yml
@@ -6,10 +6,12 @@ on:
     tags-ignore: ["enhanced_gradients-v*"]
     paths:
       - "packages/enhanced_gradients/**"
+      - ".github/workflows/enhanced_gradients-test.yml"
   pull_request:
     branches: [master]
     paths:
       - "packages/enhanced_gradients/**"
+      - ".github/workflows/enhanced_gradients-test.yml"
   # Run a check daily due to the dependency on `material_color_utilities: any`
   schedule:
     - cron: "0 17 * * *"

--- a/.github/workflows/enhanced_gradients-test.yml
+++ b/.github/workflows/enhanced_gradients-test.yml
@@ -19,6 +19,11 @@ jobs:
     name: Flutter ${{ matrix.channel }}${{ matrix.version }}
 
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      statuses: write
+
     strategy:
       fail-fast: false
       matrix:
@@ -53,3 +58,10 @@ jobs:
       - name: Dry run pub publish
         # We don't want it to fail the CI, it's just to see how would `pub publish` behave.
         run: dart pub publish --dry-run || true
+
+      - name: Score with pana
+        id: pana
+        continue-on-error: true
+        uses: leancodepl/mobile-tools/.github/actions/pana-score@pana-score-v1
+        with:
+          path: packages/enhanced_gradients

--- a/.github/workflows/enhanced_gradients-test.yml
+++ b/.github/workflows/enhanced_gradients-test.yml
@@ -22,10 +22,6 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    permissions:
-      contents: read
-      statuses: write
-
     strategy:
       fail-fast: false
       matrix:
@@ -61,9 +57,20 @@ jobs:
         # We don't want it to fail the CI, it's just to see how would `pub publish` behave.
         run: dart pub publish --dry-run || true
 
+  pana-score:
+    name: pana score
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      statuses: write
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+
       - name: Score with pana
-        id: pana
         continue-on-error: true
-        uses: leancodepl/mobile-tools/.github/actions/pana-score@68d925e42153f53e69d6c2501534f0c3c0a1a3be # v1.1
+        uses: leancodepl/mobile-tools/.github/actions/pana-score@e9f138c252f8e2254c88273367958fcc6bb39cad # pana-score-v1.3
         with:
           path: packages/enhanced_gradients

--- a/.github/workflows/leancode_analytics-test.yml
+++ b/.github/workflows/leancode_analytics-test.yml
@@ -61,6 +61,6 @@ jobs:
       - name: Score with pana
         id: pana
         continue-on-error: true
-        uses: leancodepl/mobile-tools/.github/actions/pana-score@pana-score-v1
+        uses: leancodepl/mobile-tools/.github/actions/pana-score@68d925e42153f53e69d6c2501534f0c3c0a1a3be # v1.1
         with:
           path: packages/leancode_analytics

--- a/.github/workflows/leancode_analytics-test.yml
+++ b/.github/workflows/leancode_analytics-test.yml
@@ -6,10 +6,12 @@ on:
     tags-ignore: ['leancode_analytics-v*']
     paths:
       - 'packages/leancode_analytics/**'
+      - '.github/workflows/leancode_analytics-test.yml'
   pull_request:
     branches: [master]
     paths:
       - 'packages/leancode_analytics/**'
+      - '.github/workflows/leancode_analytics-test.yml'
 
 jobs:
   test:

--- a/.github/workflows/leancode_analytics-test.yml
+++ b/.github/workflows/leancode_analytics-test.yml
@@ -16,6 +16,11 @@ jobs:
     name: Flutter ${{ matrix.channel }}${{ matrix.version }}
 
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      statuses: write
+
     strategy:
       fail-fast: false
       matrix:
@@ -50,3 +55,10 @@ jobs:
       - name: Dry run pub publish
         # We don't want it to fail the CI, it's just to see how would `pub publish` behave.
         run: dart pub publish --dry-run || true
+
+      - name: Score with pana
+        id: pana
+        continue-on-error: true
+        uses: leancodepl/mobile-tools/.github/actions/pana-score@pana-score-v1
+        with:
+          path: packages/leancode_analytics

--- a/.github/workflows/leancode_analytics-test.yml
+++ b/.github/workflows/leancode_analytics-test.yml
@@ -19,10 +19,6 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    permissions:
-      contents: read
-      statuses: write
-
     strategy:
       fail-fast: false
       matrix:
@@ -58,9 +54,20 @@ jobs:
         # We don't want it to fail the CI, it's just to see how would `pub publish` behave.
         run: dart pub publish --dry-run || true
 
+  pana-score:
+    name: pana score
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      statuses: write
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+
       - name: Score with pana
-        id: pana
         continue-on-error: true
-        uses: leancodepl/mobile-tools/.github/actions/pana-score@68d925e42153f53e69d6c2501534f0c3c0a1a3be # v1.1
+        uses: leancodepl/mobile-tools/.github/actions/pana-score@e9f138c252f8e2254c88273367958fcc6bb39cad # pana-score-v1.3
         with:
           path: packages/leancode_analytics

--- a/.github/workflows/leancode_analytics_base-test.yml
+++ b/.github/workflows/leancode_analytics_base-test.yml
@@ -61,6 +61,6 @@ jobs:
       - name: Score with pana
         id: pana
         continue-on-error: true
-        uses: leancodepl/mobile-tools/.github/actions/pana-score@pana-score-v1
+        uses: leancodepl/mobile-tools/.github/actions/pana-score@68d925e42153f53e69d6c2501534f0c3c0a1a3be # v1.1
         with:
           path: packages/leancode_analytics_base

--- a/.github/workflows/leancode_analytics_base-test.yml
+++ b/.github/workflows/leancode_analytics_base-test.yml
@@ -6,10 +6,12 @@ on:
     tags-ignore: ['leancode_analytics_base-v*']
     paths:
       - 'packages/leancode_analytics_base/**'
+      - '.github/workflows/leancode_analytics_base-test.yml'
   pull_request:
     branches: [master]
     paths:
       - 'packages/leancode_analytics_base/**'
+      - '.github/workflows/leancode_analytics_base-test.yml'
 
 jobs:
   test:

--- a/.github/workflows/leancode_analytics_base-test.yml
+++ b/.github/workflows/leancode_analytics_base-test.yml
@@ -19,10 +19,6 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    permissions:
-      contents: read
-      statuses: write
-
     strategy:
       fail-fast: false
       matrix:
@@ -58,9 +54,20 @@ jobs:
         # We don't want it to fail the CI, it's just to see how would `pub publish` behave.
         run: dart pub publish --dry-run || true
 
+  pana-score:
+    name: pana score
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      statuses: write
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+
       - name: Score with pana
-        id: pana
         continue-on-error: true
-        uses: leancodepl/mobile-tools/.github/actions/pana-score@68d925e42153f53e69d6c2501534f0c3c0a1a3be # v1.1
+        uses: leancodepl/mobile-tools/.github/actions/pana-score@e9f138c252f8e2254c88273367958fcc6bb39cad # pana-score-v1.3
         with:
           path: packages/leancode_analytics_base

--- a/.github/workflows/leancode_analytics_base-test.yml
+++ b/.github/workflows/leancode_analytics_base-test.yml
@@ -16,6 +16,11 @@ jobs:
     name: Flutter ${{ matrix.channel }}${{ matrix.version }}
 
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      statuses: write
+
     strategy:
       fail-fast: false
       matrix:
@@ -50,3 +55,10 @@ jobs:
       - name: Dry run pub publish
         # We don't want it to fail the CI, it's just to see how would `pub publish` behave.
         run: dart pub publish --dry-run || true
+
+      - name: Score with pana
+        id: pana
+        continue-on-error: true
+        uses: leancodepl/mobile-tools/.github/actions/pana-score@pana-score-v1
+        with:
+          path: packages/leancode_analytics_base

--- a/.github/workflows/leancode_analytics_firebase-test.yml
+++ b/.github/workflows/leancode_analytics_firebase-test.yml
@@ -18,6 +18,11 @@ jobs:
     name: Flutter ${{ matrix.channel }}${{ matrix.version }}
 
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      statuses: write
+
     strategy:
       fail-fast: false
       matrix:
@@ -58,3 +63,10 @@ jobs:
       - name: Dry run pub publish
         # We don't want it to fail the CI, it's just to see how would `pub publish` behave.
         run: dart pub publish --dry-run || true
+
+      - name: Score with pana
+        id: pana
+        continue-on-error: true
+        uses: leancodepl/mobile-tools/.github/actions/pana-score@pana-score-v1
+        with:
+          path: packages/leancode_analytics_firebase

--- a/.github/workflows/leancode_analytics_firebase-test.yml
+++ b/.github/workflows/leancode_analytics_firebase-test.yml
@@ -69,6 +69,6 @@ jobs:
       - name: Score with pana
         id: pana
         continue-on-error: true
-        uses: leancodepl/mobile-tools/.github/actions/pana-score@pana-score-v1
+        uses: leancodepl/mobile-tools/.github/actions/pana-score@68d925e42153f53e69d6c2501534f0c3c0a1a3be # v1.1
         with:
           path: packages/leancode_analytics_firebase

--- a/.github/workflows/leancode_analytics_firebase-test.yml
+++ b/.github/workflows/leancode_analytics_firebase-test.yml
@@ -7,11 +7,13 @@ on:
     paths:
       - 'packages/leancode_analytics_firebase/**'
       - 'packages/leancode_analytics_base/**'
+      - '.github/workflows/leancode_analytics_firebase-test.yml'
   pull_request:
     branches: [master]
     paths:
       - 'packages/leancode_analytics_firebase/**'
       - 'packages/leancode_analytics_base/**'
+      - '.github/workflows/leancode_analytics_firebase-test.yml'
 
 jobs:
   test:

--- a/.github/workflows/leancode_analytics_firebase-test.yml
+++ b/.github/workflows/leancode_analytics_firebase-test.yml
@@ -21,10 +21,6 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    permissions:
-      contents: read
-      statuses: write
-
     strategy:
       fail-fast: false
       matrix:
@@ -66,9 +62,20 @@ jobs:
         # We don't want it to fail the CI, it's just to see how would `pub publish` behave.
         run: dart pub publish --dry-run || true
 
+  pana-score:
+    name: pana score
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      statuses: write
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+
       - name: Score with pana
-        id: pana
         continue-on-error: true
-        uses: leancodepl/mobile-tools/.github/actions/pana-score@68d925e42153f53e69d6c2501534f0c3c0a1a3be # v1.1
+        uses: leancodepl/mobile-tools/.github/actions/pana-score@e9f138c252f8e2254c88273367958fcc6bb39cad # pana-score-v1.3
         with:
           path: packages/leancode_analytics_firebase

--- a/.github/workflows/leancode_analytics_posthog-test.yml
+++ b/.github/workflows/leancode_analytics_posthog-test.yml
@@ -18,6 +18,11 @@ jobs:
     name: Flutter ${{ matrix.channel }}${{ matrix.version }}
 
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      statuses: write
+
     strategy:
       fail-fast: false
       matrix:
@@ -58,3 +63,10 @@ jobs:
       - name: Dry run pub publish
         # We don't want it to fail the CI, it's just to see how would `pub publish` behave.
         run: dart pub publish --dry-run || true
+
+      - name: Score with pana
+        id: pana
+        continue-on-error: true
+        uses: leancodepl/mobile-tools/.github/actions/pana-score@pana-score-v1
+        with:
+          path: packages/leancode_analytics_posthog

--- a/.github/workflows/leancode_analytics_posthog-test.yml
+++ b/.github/workflows/leancode_analytics_posthog-test.yml
@@ -7,11 +7,13 @@ on:
     paths:
       - 'packages/leancode_analytics_posthog/**'
       - 'packages/leancode_analytics_base/**'
+      - '.github/workflows/leancode_analytics_posthog-test.yml'
   pull_request:
     branches: [master]
     paths:
       - 'packages/leancode_analytics_posthog/**'
       - 'packages/leancode_analytics_base/**'
+      - '.github/workflows/leancode_analytics_posthog-test.yml'
 
 jobs:
   test:

--- a/.github/workflows/leancode_analytics_posthog-test.yml
+++ b/.github/workflows/leancode_analytics_posthog-test.yml
@@ -21,10 +21,6 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    permissions:
-      contents: read
-      statuses: write
-
     strategy:
       fail-fast: false
       matrix:
@@ -66,9 +62,20 @@ jobs:
         # We don't want it to fail the CI, it's just to see how would `pub publish` behave.
         run: dart pub publish --dry-run || true
 
+  pana-score:
+    name: pana score
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      statuses: write
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+
       - name: Score with pana
-        id: pana
         continue-on-error: true
-        uses: leancodepl/mobile-tools/.github/actions/pana-score@68d925e42153f53e69d6c2501534f0c3c0a1a3be # v1.1
+        uses: leancodepl/mobile-tools/.github/actions/pana-score@e9f138c252f8e2254c88273367958fcc6bb39cad # pana-score-v1.3
         with:
           path: packages/leancode_analytics_posthog

--- a/.github/workflows/leancode_analytics_posthog-test.yml
+++ b/.github/workflows/leancode_analytics_posthog-test.yml
@@ -69,6 +69,6 @@ jobs:
       - name: Score with pana
         id: pana
         continue-on-error: true
-        uses: leancodepl/mobile-tools/.github/actions/pana-score@pana-score-v1
+        uses: leancodepl/mobile-tools/.github/actions/pana-score@68d925e42153f53e69d6c2501534f0c3c0a1a3be # v1.1
         with:
           path: packages/leancode_analytics_posthog

--- a/.github/workflows/leancode_cyberware_contract_base-test.yml
+++ b/.github/workflows/leancode_cyberware_contract_base-test.yml
@@ -6,10 +6,12 @@ on:
     tags-ignore: ['leancode_cyberware_contract_base-v*']
     paths:
       - 'packages/leancode_cyberware_contract_base/**'
+      - '.github/workflows/leancode_cyberware_contract_base-test.yml'
   pull_request:
     branches: [master]
     paths:
       - 'packages/leancode_cyberware_contract_base/**'
+      - '.github/workflows/leancode_cyberware_contract_base-test.yml'
 
 jobs:
   test:

--- a/.github/workflows/leancode_cyberware_contract_base-test.yml
+++ b/.github/workflows/leancode_cyberware_contract_base-test.yml
@@ -69,6 +69,6 @@ jobs:
       - name: Score with pana
         id: pana
         continue-on-error: true
-        uses: leancodepl/mobile-tools/.github/actions/pana-score@pana-score-v1
+        uses: leancodepl/mobile-tools/.github/actions/pana-score@68d925e42153f53e69d6c2501534f0c3c0a1a3be # v1.1
         with:
           path: packages/leancode_cyberware_contract_base

--- a/.github/workflows/leancode_cyberware_contract_base-test.yml
+++ b/.github/workflows/leancode_cyberware_contract_base-test.yml
@@ -19,10 +19,6 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    permissions:
-      contents: read
-      statuses: write
-
     strategy:
       fail-fast: false
       matrix:
@@ -66,9 +62,20 @@ jobs:
         # We don't want it to fail the CI, it's just to see how would `pub publish` behave.
         run: dart pub publish --dry-run || true
 
+  pana-score:
+    name: pana score
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      statuses: write
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+
       - name: Score with pana
-        id: pana
         continue-on-error: true
-        uses: leancodepl/mobile-tools/.github/actions/pana-score@68d925e42153f53e69d6c2501534f0c3c0a1a3be # v1.1
+        uses: leancodepl/mobile-tools/.github/actions/pana-score@e9f138c252f8e2254c88273367958fcc6bb39cad # pana-score-v1.3
         with:
           path: packages/leancode_cyberware_contract_base

--- a/.github/workflows/leancode_cyberware_contract_base-test.yml
+++ b/.github/workflows/leancode_cyberware_contract_base-test.yml
@@ -16,6 +16,11 @@ jobs:
     name: Flutter ${{ matrix.flutter_version }}
 
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      statuses: write
+
     strategy:
       fail-fast: false
       matrix:
@@ -58,3 +63,10 @@ jobs:
       - name: Dry run pub publish
         # We don't want it to fail the CI, it's just to see how would `pub publish` behave.
         run: dart pub publish --dry-run || true
+
+      - name: Score with pana
+        id: pana
+        continue-on-error: true
+        uses: leancodepl/mobile-tools/.github/actions/pana-score@pana-score-v1
+        with:
+          path: packages/leancode_cyberware_contract_base

--- a/.github/workflows/leancode_debug_page-test.yml
+++ b/.github/workflows/leancode_debug_page-test.yml
@@ -61,6 +61,6 @@ jobs:
       - name: Score with pana
         id: pana
         continue-on-error: true
-        uses: leancodepl/mobile-tools/.github/actions/pana-score@pana-score-v1
+        uses: leancodepl/mobile-tools/.github/actions/pana-score@68d925e42153f53e69d6c2501534f0c3c0a1a3be # v1.1
         with:
           path: packages/leancode_debug_page

--- a/.github/workflows/leancode_debug_page-test.yml
+++ b/.github/workflows/leancode_debug_page-test.yml
@@ -6,10 +6,12 @@ on:
     tags-ignore: ['leancode_debug_page-v*']
     paths:
       - 'packages/leancode_debug_page/**'
+      - '.github/workflows/leancode_debug_page-test.yml'
   pull_request:
     branches: [master]
     paths:
       - 'packages/leancode_debug_page/**'
+      - '.github/workflows/leancode_debug_page-test.yml'
 
 jobs:
   test:

--- a/.github/workflows/leancode_debug_page-test.yml
+++ b/.github/workflows/leancode_debug_page-test.yml
@@ -19,10 +19,6 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    permissions:
-      contents: read
-      statuses: write
-
     strategy:
       fail-fast: false
       matrix:
@@ -58,9 +54,20 @@ jobs:
         # We don't want it to fail the CI, it's just to see how would `pub publish` behave.
         run: dart pub publish --dry-run || true
 
+  pana-score:
+    name: pana score
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      statuses: write
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+
       - name: Score with pana
-        id: pana
         continue-on-error: true
-        uses: leancodepl/mobile-tools/.github/actions/pana-score@68d925e42153f53e69d6c2501534f0c3c0a1a3be # v1.1
+        uses: leancodepl/mobile-tools/.github/actions/pana-score@e9f138c252f8e2254c88273367958fcc6bb39cad # pana-score-v1.3
         with:
           path: packages/leancode_debug_page

--- a/.github/workflows/leancode_debug_page-test.yml
+++ b/.github/workflows/leancode_debug_page-test.yml
@@ -16,6 +16,11 @@ jobs:
     name: Flutter ${{ matrix.channel }}${{ matrix.version }}
 
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      statuses: write
+
     strategy:
       fail-fast: false
       matrix:
@@ -50,3 +55,10 @@ jobs:
       - name: Dry run pub publish
         # We don't want it to fail the CI, it's just to see how would `pub publish` behave.
         run: dart pub publish --dry-run || true
+
+      - name: Score with pana
+        id: pana
+        continue-on-error: true
+        uses: leancodepl/mobile-tools/.github/actions/pana-score@pana-score-v1
+        with:
+          path: packages/leancode_debug_page

--- a/.github/workflows/leancode_flutter_svg_adaptive_loader-test.yml
+++ b/.github/workflows/leancode_flutter_svg_adaptive_loader-test.yml
@@ -19,10 +19,6 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    permissions:
-      contents: read
-      statuses: write
-
     strategy:
       fail-fast: false
       matrix:
@@ -59,9 +55,20 @@ jobs:
         # We don't want it to fail the CI, it's just to see how would `pub publish` behave.
         run: flutter pub publish --dry-run || true
 
+  pana-score:
+    name: pana score
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      statuses: write
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+
       - name: Score with pana
-        id: pana
         continue-on-error: true
-        uses: leancodepl/mobile-tools/.github/actions/pana-score@68d925e42153f53e69d6c2501534f0c3c0a1a3be # v1.1
+        uses: leancodepl/mobile-tools/.github/actions/pana-score@e9f138c252f8e2254c88273367958fcc6bb39cad # pana-score-v1.3
         with:
           path: packages/leancode_flutter_svg_adaptive_loader

--- a/.github/workflows/leancode_flutter_svg_adaptive_loader-test.yml
+++ b/.github/workflows/leancode_flutter_svg_adaptive_loader-test.yml
@@ -6,10 +6,12 @@ on:
     tags-ignore: ['leancode_flutter_svg_adaptive_loader-v*']
     paths:
       - 'packages/leancode_flutter_svg_adaptive_loader/**'
+      - '.github/workflows/leancode_flutter_svg_adaptive_loader-test.yml'
   pull_request:
     branches: [master]
     paths:
       - 'packages/leancode_flutter_svg_adaptive_loader/**'
+      - '.github/workflows/leancode_flutter_svg_adaptive_loader-test.yml'
 
 jobs:
   test:

--- a/.github/workflows/leancode_flutter_svg_adaptive_loader-test.yml
+++ b/.github/workflows/leancode_flutter_svg_adaptive_loader-test.yml
@@ -62,6 +62,6 @@ jobs:
       - name: Score with pana
         id: pana
         continue-on-error: true
-        uses: leancodepl/mobile-tools/.github/actions/pana-score@pana-score-v1
+        uses: leancodepl/mobile-tools/.github/actions/pana-score@68d925e42153f53e69d6c2501534f0c3c0a1a3be # v1.1
         with:
           path: packages/leancode_flutter_svg_adaptive_loader

--- a/.github/workflows/leancode_flutter_svg_adaptive_loader-test.yml
+++ b/.github/workflows/leancode_flutter_svg_adaptive_loader-test.yml
@@ -16,6 +16,11 @@ jobs:
     name: Flutter ${{ matrix.channel }}${{ matrix.version }}
 
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      statuses: write
+
     strategy:
       fail-fast: false
       matrix:
@@ -51,3 +56,10 @@ jobs:
       - name: Dry run pub publish
         # We don't want it to fail the CI, it's just to see how would `pub publish` behave.
         run: flutter pub publish --dry-run || true
+
+      - name: Score with pana
+        id: pana
+        continue-on-error: true
+        uses: leancodepl/mobile-tools/.github/actions/pana-score@pana-score-v1
+        with:
+          path: packages/leancode_flutter_svg_adaptive_loader

--- a/.github/workflows/leancode_force_update-test.yml
+++ b/.github/workflows/leancode_force_update-test.yml
@@ -16,6 +16,11 @@ jobs:
     name: Flutter ${{ matrix.channel }}${{ matrix.version }}
 
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      statuses: write
+
     strategy:
       fail-fast: false
       matrix:
@@ -52,3 +57,10 @@ jobs:
       - name: Dry run pub publish
         # We don't want it to fail the CI, it's just to see how would `pub publish` behave.
         run: flutter pub publish --dry-run || true
+
+      - name: Score with pana
+        id: pana
+        continue-on-error: true
+        uses: leancodepl/mobile-tools/.github/actions/pana-score@pana-score-v1
+        with:
+          path: packages/leancode_force_update

--- a/.github/workflows/leancode_force_update-test.yml
+++ b/.github/workflows/leancode_force_update-test.yml
@@ -63,6 +63,6 @@ jobs:
       - name: Score with pana
         id: pana
         continue-on-error: true
-        uses: leancodepl/mobile-tools/.github/actions/pana-score@pana-score-v1
+        uses: leancodepl/mobile-tools/.github/actions/pana-score@68d925e42153f53e69d6c2501534f0c3c0a1a3be # v1.1
         with:
           path: packages/leancode_force_update

--- a/.github/workflows/leancode_force_update-test.yml
+++ b/.github/workflows/leancode_force_update-test.yml
@@ -6,10 +6,12 @@ on:
     tags-ignore: ['leancode_force_update-v*']
     paths:
       - 'packages/leancode_force_update/**'
+      - '.github/workflows/leancode_force_update-test.yml'
   pull_request:
     branches: [master]
     paths:
       - 'packages/leancode_force_update/**'
+      - '.github/workflows/leancode_force_update-test.yml'
 
 jobs:
   test:

--- a/.github/workflows/leancode_force_update-test.yml
+++ b/.github/workflows/leancode_force_update-test.yml
@@ -19,10 +19,6 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    permissions:
-      contents: read
-      statuses: write
-
     strategy:
       fail-fast: false
       matrix:
@@ -60,9 +56,20 @@ jobs:
         # We don't want it to fail the CI, it's just to see how would `pub publish` behave.
         run: flutter pub publish --dry-run || true
 
+  pana-score:
+    name: pana score
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      statuses: write
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+
       - name: Score with pana
-        id: pana
         continue-on-error: true
-        uses: leancodepl/mobile-tools/.github/actions/pana-score@68d925e42153f53e69d6c2501534f0c3c0a1a3be # v1.1
+        uses: leancodepl/mobile-tools/.github/actions/pana-score@e9f138c252f8e2254c88273367958fcc6bb39cad # pana-score-v1.3
         with:
           path: packages/leancode_force_update

--- a/.github/workflows/leancode_hooks-test.yml
+++ b/.github/workflows/leancode_hooks-test.yml
@@ -16,6 +16,11 @@ jobs:
     name: Flutter ${{ matrix.channel }}${{ matrix.version }}
 
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      statuses: write
+
     strategy:
       fail-fast: false
       matrix:
@@ -58,3 +63,10 @@ jobs:
       - uses: codecov/codecov-action@v1
         with:
           flags: leancode_hooks
+
+      - name: Score with pana
+        id: pana
+        continue-on-error: true
+        uses: leancodepl/mobile-tools/.github/actions/pana-score@pana-score-v1
+        with:
+          path: packages/leancode_hooks

--- a/.github/workflows/leancode_hooks-test.yml
+++ b/.github/workflows/leancode_hooks-test.yml
@@ -19,10 +19,6 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    permissions:
-      contents: read
-      statuses: write
-
     strategy:
       fail-fast: false
       matrix:
@@ -66,9 +62,20 @@ jobs:
         with:
           flags: leancode_hooks
 
+  pana-score:
+    name: pana score
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      statuses: write
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+
       - name: Score with pana
-        id: pana
         continue-on-error: true
-        uses: leancodepl/mobile-tools/.github/actions/pana-score@68d925e42153f53e69d6c2501534f0c3c0a1a3be # v1.1
+        uses: leancodepl/mobile-tools/.github/actions/pana-score@e9f138c252f8e2254c88273367958fcc6bb39cad # pana-score-v1.3
         with:
           path: packages/leancode_hooks

--- a/.github/workflows/leancode_hooks-test.yml
+++ b/.github/workflows/leancode_hooks-test.yml
@@ -6,10 +6,12 @@ on:
     tags-ignore: ['leancode_hooks-v*']
     paths:
       - 'packages/leancode_hooks/**'
+      - '.github/workflows/leancode_hooks-test.yml'
   pull_request:
     branches: [master]
     paths:
       - 'packages/leancode_hooks/**'
+      - '.github/workflows/leancode_hooks-test.yml'
 
 jobs:
   test:

--- a/.github/workflows/leancode_hooks-test.yml
+++ b/.github/workflows/leancode_hooks-test.yml
@@ -69,6 +69,6 @@ jobs:
       - name: Score with pana
         id: pana
         continue-on-error: true
-        uses: leancodepl/mobile-tools/.github/actions/pana-score@pana-score-v1
+        uses: leancodepl/mobile-tools/.github/actions/pana-score@68d925e42153f53e69d6c2501534f0c3c0a1a3be # v1.1
         with:
           path: packages/leancode_hooks

--- a/.github/workflows/leancode_lint-test.yml
+++ b/.github/workflows/leancode_lint-test.yml
@@ -19,10 +19,6 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    permissions:
-      contents: read
-      statuses: write
-
     strategy:
       fail-fast: false
       matrix:
@@ -54,9 +50,20 @@ jobs:
         with:
           flags: leancode_lint
 
+  pana-score:
+    name: pana score
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      statuses: write
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+
       - name: Score with pana
-        id: pana
         continue-on-error: true
-        uses: leancodepl/mobile-tools/.github/actions/pana-score@68d925e42153f53e69d6c2501534f0c3c0a1a3be # v1.1
+        uses: leancodepl/mobile-tools/.github/actions/pana-score@e9f138c252f8e2254c88273367958fcc6bb39cad # pana-score-v1.3
         with:
           path: packages/leancode_lint

--- a/.github/workflows/leancode_lint-test.yml
+++ b/.github/workflows/leancode_lint-test.yml
@@ -16,6 +16,11 @@ jobs:
     name: Flutter ${{ matrix.channel }}${{ matrix.version }}
 
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      statuses: write
+
     strategy:
       fail-fast: false
       matrix:
@@ -46,3 +51,10 @@ jobs:
       - uses: codecov/codecov-action@v1
         with:
           flags: leancode_lint
+
+      - name: Score with pana
+        id: pana
+        continue-on-error: true
+        uses: leancodepl/mobile-tools/.github/actions/pana-score@pana-score-v1
+        with:
+          path: packages/leancode_lint

--- a/.github/workflows/leancode_lint-test.yml
+++ b/.github/workflows/leancode_lint-test.yml
@@ -57,6 +57,6 @@ jobs:
       - name: Score with pana
         id: pana
         continue-on-error: true
-        uses: leancodepl/mobile-tools/.github/actions/pana-score@pana-score-v1
+        uses: leancodepl/mobile-tools/.github/actions/pana-score@68d925e42153f53e69d6c2501534f0c3c0a1a3be # v1.1
         with:
           path: packages/leancode_lint

--- a/.github/workflows/leancode_lint-test.yml
+++ b/.github/workflows/leancode_lint-test.yml
@@ -6,10 +6,12 @@ on:
     tags-ignore: ['leancode_lint-v*']
     paths:
       - 'packages/leancode_lint/**'
+      - '.github/workflows/leancode_lint-test.yml'
   pull_request:
     branches: [master]
     paths:
       - 'packages/leancode_lint/**'
+      - '.github/workflows/leancode_lint-test.yml'
 
 jobs:
   test:

--- a/.github/workflows/leancode_markup-test.yml
+++ b/.github/workflows/leancode_markup-test.yml
@@ -6,10 +6,12 @@ on:
     tags-ignore: ['leancode_markup-v*']
     paths:
       - 'packages/leancode_markup/**'
+      - '.github/workflows/leancode_markup-test.yml'
   pull_request:
     branches: [master]
     paths:
       - 'packages/leancode_markup/**'
+      - '.github/workflows/leancode_markup-test.yml'
 
 jobs:
   test:

--- a/.github/workflows/leancode_markup-test.yml
+++ b/.github/workflows/leancode_markup-test.yml
@@ -66,6 +66,6 @@ jobs:
       - name: Score with pana
         id: pana
         continue-on-error: true
-        uses: leancodepl/mobile-tools/.github/actions/pana-score@pana-score-v1
+        uses: leancodepl/mobile-tools/.github/actions/pana-score@68d925e42153f53e69d6c2501534f0c3c0a1a3be # v1.1
         with:
           path: packages/leancode_markup

--- a/.github/workflows/leancode_markup-test.yml
+++ b/.github/workflows/leancode_markup-test.yml
@@ -19,10 +19,6 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    permissions:
-      contents: read
-      statuses: write
-
     strategy:
       fail-fast: false
       matrix:
@@ -63,9 +59,20 @@ jobs:
         # We don't want it to fail the CI, it's just to see how would `pub publish` behave.
         run: dart pub publish --dry-run || true
 
+  pana-score:
+    name: pana score
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      statuses: write
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+
       - name: Score with pana
-        id: pana
         continue-on-error: true
-        uses: leancodepl/mobile-tools/.github/actions/pana-score@68d925e42153f53e69d6c2501534f0c3c0a1a3be # v1.1
+        uses: leancodepl/mobile-tools/.github/actions/pana-score@e9f138c252f8e2254c88273367958fcc6bb39cad # pana-score-v1.3
         with:
           path: packages/leancode_markup

--- a/.github/workflows/leancode_markup-test.yml
+++ b/.github/workflows/leancode_markup-test.yml
@@ -16,6 +16,11 @@ jobs:
     name: Flutter ${{ matrix.channel }}${{ matrix.version }}
 
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      statuses: write
+
     strategy:
       fail-fast: false
       matrix:
@@ -55,3 +60,10 @@ jobs:
       - name: Dry run pub publish
         # We don't want it to fail the CI, it's just to see how would `pub publish` behave.
         run: dart pub publish --dry-run || true
+
+      - name: Score with pana
+        id: pana
+        continue-on-error: true
+        uses: leancodepl/mobile-tools/.github/actions/pana-score@pana-score-v1
+        with:
+          path: packages/leancode_markup

--- a/.github/workflows/login_client-test.yml
+++ b/.github/workflows/login_client-test.yml
@@ -6,10 +6,12 @@ on:
     tags-ignore: ['login_client-v*']
     paths:
       - 'packages/login_client/**'
+      - '.github/workflows/login_client-test.yml'
   pull_request:
     branches: [master]
     paths:
       - 'packages/login_client/**'
+      - '.github/workflows/login_client-test.yml'
 
 jobs:
   test:

--- a/.github/workflows/login_client-test.yml
+++ b/.github/workflows/login_client-test.yml
@@ -16,6 +16,11 @@ jobs:
     name: Dart ${{ matrix.dart_release }}
 
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      statuses: write
+
     strategy:
       fail-fast: false
       matrix:
@@ -64,3 +69,10 @@ jobs:
       - uses: codecov/codecov-action@v1
         with:
           flags: login_client
+
+      - name: Score with pana
+        id: pana
+        continue-on-error: true
+        uses: leancodepl/mobile-tools/.github/actions/pana-score@pana-score-v1
+        with:
+          path: packages/login_client

--- a/.github/workflows/login_client-test.yml
+++ b/.github/workflows/login_client-test.yml
@@ -19,10 +19,6 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    permissions:
-      contents: read
-      statuses: write
-
     strategy:
       fail-fast: false
       matrix:
@@ -72,9 +68,20 @@ jobs:
         with:
           flags: login_client
 
+  pana-score:
+    name: pana score
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      statuses: write
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+
       - name: Score with pana
-        id: pana
         continue-on-error: true
-        uses: leancodepl/mobile-tools/.github/actions/pana-score@68d925e42153f53e69d6c2501534f0c3c0a1a3be # v1.1
+        uses: leancodepl/mobile-tools/.github/actions/pana-score@e9f138c252f8e2254c88273367958fcc6bb39cad # pana-score-v1.3
         with:
           path: packages/login_client

--- a/.github/workflows/login_client-test.yml
+++ b/.github/workflows/login_client-test.yml
@@ -75,6 +75,6 @@ jobs:
       - name: Score with pana
         id: pana
         continue-on-error: true
-        uses: leancodepl/mobile-tools/.github/actions/pana-score@pana-score-v1
+        uses: leancodepl/mobile-tools/.github/actions/pana-score@68d925e42153f53e69d6c2501534f0c3c0a1a3be # v1.1
         with:
           path: packages/login_client

--- a/.github/workflows/login_client_flutter-test.yml
+++ b/.github/workflows/login_client_flutter-test.yml
@@ -62,6 +62,6 @@ jobs:
       - name: Score with pana
         id: pana
         continue-on-error: true
-        uses: leancodepl/mobile-tools/.github/actions/pana-score@pana-score-v1
+        uses: leancodepl/mobile-tools/.github/actions/pana-score@68d925e42153f53e69d6c2501534f0c3c0a1a3be # v1.1
         with:
           path: packages/login_client_flutter

--- a/.github/workflows/login_client_flutter-test.yml
+++ b/.github/workflows/login_client_flutter-test.yml
@@ -19,10 +19,6 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    permissions:
-      contents: read
-      statuses: write
-
     strategy:
       fail-fast: false
       matrix:
@@ -59,9 +55,20 @@ jobs:
         # We don't want it to fail the CI, it's just to see how would `pub publish` behave.
         run: dart pub publish --dry-run || true
 
+  pana-score:
+    name: pana score
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      statuses: write
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+
       - name: Score with pana
-        id: pana
         continue-on-error: true
-        uses: leancodepl/mobile-tools/.github/actions/pana-score@68d925e42153f53e69d6c2501534f0c3c0a1a3be # v1.1
+        uses: leancodepl/mobile-tools/.github/actions/pana-score@e9f138c252f8e2254c88273367958fcc6bb39cad # pana-score-v1.3
         with:
           path: packages/login_client_flutter

--- a/.github/workflows/login_client_flutter-test.yml
+++ b/.github/workflows/login_client_flutter-test.yml
@@ -16,6 +16,11 @@ jobs:
     name: Flutter ${{ matrix.channel }}${{ matrix.version }}
 
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      statuses: write
+
     strategy:
       fail-fast: false
       matrix:
@@ -51,3 +56,10 @@ jobs:
       - name: Dry run pub publish
         # We don't want it to fail the CI, it's just to see how would `pub publish` behave.
         run: dart pub publish --dry-run || true
+
+      - name: Score with pana
+        id: pana
+        continue-on-error: true
+        uses: leancodepl/mobile-tools/.github/actions/pana-score@pana-score-v1
+        with:
+          path: packages/login_client_flutter

--- a/.github/workflows/login_client_flutter-test.yml
+++ b/.github/workflows/login_client_flutter-test.yml
@@ -6,10 +6,12 @@ on:
     tags-ignore: ['login_client_flutter-v*']
     paths:
       - 'packages/login_client_flutter/**'
+      - '.github/workflows/login_client_flutter-test.yml'
   pull_request:
     branches: [master]
     paths:
       - 'packages/login_client_flutter/**'
+      - '.github/workflows/login_client_flutter-test.yml'
 
 jobs:
   test:

--- a/.github/workflows/override_api_endpoint-test.yml
+++ b/.github/workflows/override_api_endpoint-test.yml
@@ -19,10 +19,6 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    permissions:
-      contents: read
-      statuses: write
-
     strategy:
       fail-fast: false
       matrix:
@@ -59,9 +55,20 @@ jobs:
         # We don't want it to fail the CI, it's just to see how would `pub publish` behave.
         run: dart pub publish --dry-run || true
 
+  pana-score:
+    name: pana score
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      statuses: write
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+
       - name: Score with pana
-        id: pana
         continue-on-error: true
-        uses: leancodepl/mobile-tools/.github/actions/pana-score@68d925e42153f53e69d6c2501534f0c3c0a1a3be # v1.1
+        uses: leancodepl/mobile-tools/.github/actions/pana-score@e9f138c252f8e2254c88273367958fcc6bb39cad # pana-score-v1.3
         with:
           path: packages/override_api_endpoint

--- a/.github/workflows/override_api_endpoint-test.yml
+++ b/.github/workflows/override_api_endpoint-test.yml
@@ -62,6 +62,6 @@ jobs:
       - name: Score with pana
         id: pana
         continue-on-error: true
-        uses: leancodepl/mobile-tools/.github/actions/pana-score@pana-score-v1
+        uses: leancodepl/mobile-tools/.github/actions/pana-score@68d925e42153f53e69d6c2501534f0c3c0a1a3be # v1.1
         with:
           path: packages/override_api_endpoint

--- a/.github/workflows/override_api_endpoint-test.yml
+++ b/.github/workflows/override_api_endpoint-test.yml
@@ -16,6 +16,11 @@ jobs:
     name: Flutter ${{ matrix.channel }}${{ matrix.version }}
 
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      statuses: write
+
     strategy:
       fail-fast: false
       matrix:
@@ -51,3 +56,10 @@ jobs:
       - name: Dry run pub publish
         # We don't want it to fail the CI, it's just to see how would `pub publish` behave.
         run: dart pub publish --dry-run || true
+
+      - name: Score with pana
+        id: pana
+        continue-on-error: true
+        uses: leancodepl/mobile-tools/.github/actions/pana-score@pana-score-v1
+        with:
+          path: packages/override_api_endpoint

--- a/.github/workflows/override_api_endpoint-test.yml
+++ b/.github/workflows/override_api_endpoint-test.yml
@@ -6,10 +6,12 @@ on:
     tags-ignore: ['override_api_endpoint-v*']
     paths:
       - 'packages/override_api_endpoint/**'
+      - '.github/workflows/override_api_endpoint-test.yml'
   pull_request:
     branches: [master]
     paths:
       - 'packages/override_api_endpoint/**'
+      - '.github/workflows/override_api_endpoint-test.yml'
 
 jobs:
   test:

--- a/packages/leancode_lint/lib/src/lints/avoid_direct_collection_equality_checks.dart
+++ b/packages/leancode_lint/lib/src/lints/avoid_direct_collection_equality_checks.dart
@@ -230,11 +230,7 @@ class ReplaceWithCollectionPackageEqualityFix
           builder.write('const ${kind.collectionClass}');
           if (typeArguments.isNotEmpty) {
             builder
-              ..writeTypes(
-                typeArguments,
-                prefix: '<',
-                shouldWriteDynamic: true,
-              )
+              ..writeTypes(typeArguments, prefix: '<', shouldWriteDynamic: true)
               ..write('>');
           }
           builder.write('().equals($left, $right)');

--- a/packages/leancode_lint/test/test_cases/missing_equatable_props_test.dart
+++ b/packages/leancode_lint/test/test_cases/missing_equatable_props_test.dart
@@ -250,7 +250,8 @@ class Sub extends Parent {
 ''');
   }
 
-  Future<void> test_super_props_not_suggested_for_direct_equatable_subclass() async {
+  Future<void>
+  test_super_props_not_suggested_for_direct_equatable_subclass() async {
     await assertDiagnosticsInRanges('''
 import 'package:equatable/equatable.dart';
 
@@ -266,7 +267,8 @@ class MyState extends Equatable {
 ''');
   }
 
-  Future<void> test_super_props_not_suggested_when_parent_has_no_concrete_props() async {
+  Future<void>
+  test_super_props_not_suggested_when_parent_has_no_concrete_props() async {
     await assertDiagnosticsInRanges('''
 import 'package:equatable/equatable.dart';
 
@@ -286,7 +288,8 @@ class Sub extends AbstractBase {
 ''');
   }
 
-  Future<void> test_no_diagnostic_when_parent_has_no_concrete_props_and_all_fields_listed() async {
+  Future<void>
+  test_no_diagnostic_when_parent_has_no_concrete_props_and_all_fields_listed() async {
     await assertNoDiagnostics('''
 import 'package:equatable/equatable.dart';
 
@@ -306,7 +309,8 @@ class Sub extends AbstractBase {
 ''');
   }
 
-  Future<void> test_super_props_suggested_when_abstract_parent_has_concrete_props() async {
+  Future<void>
+  test_super_props_suggested_when_abstract_parent_has_concrete_props() async {
     await assertDiagnosticsInRanges('''
 import 'package:equatable/equatable.dart';
 

--- a/packages/override_api_endpoint/pubspec.yaml
+++ b/packages/override_api_endpoint/pubspec.yaml
@@ -13,6 +13,8 @@ environment:
   flutter: '>=2.0.0'
 
 dependencies:
+  flutter:
+    sdk: flutter
   shared_preferences: ^2.0.6
 
 dev_dependencies:


### PR DESCRIPTION
Runs leancodepl/mobile-tools pana-score action after each package's test job to surface pub.dev-style scoring as a commit status and step summary, without failing CI on a low score.