### PR TITLE
[leancode_debug_page] Keep text legible on the debug page's own colors

### DIFF
--- a/packages/leancode_debug_page/CHANGELOG.md
+++ b/packages/leancode_debug_page/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.1.3
+
+- Fix illegible text on log tiles, the log details app bar and the entry button in apps whose theme foregrounds don't happen to contrast with them.
+
 ## 3.1.2
 
 - Upgrade `share_plus` dependency to `^13.2.0`

--- a/packages/leancode_debug_page/example/pubspec.lock
+++ b/packages/leancode_debug_page/example/pubspec.lock
@@ -174,7 +174,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "3.1.2"
+    version: "3.1.3"
   lints:
     dependency: transitive
     description:

--- a/packages/leancode_debug_page/lib/src/ui/debug_page_button.dart
+++ b/packages/leancode_debug_page/lib/src/ui/debug_page_button.dart
@@ -49,16 +49,17 @@ class _DraggableFloatingButtonState extends State<_DraggableFloatingButton> {
     final Size(:height, :width) = MediaQuery.sizeOf(context);
     final horizontalCenter = width / 2;
     final verticalCenter = height / 2;
+    final colorScheme = Theme.of(context).colorScheme;
 
     final floatingActionButton = GestureDetector(
       onTap: () => widget._controller.open(),
       child: Container(
         padding: const EdgeInsets.all(16),
         decoration: BoxDecoration(
-          color: Theme.of(context).colorScheme.primaryContainer,
+          color: colorScheme.primaryContainer,
           borderRadius: BorderRadius.circular(16),
         ),
-        child: const Icon(Icons.bug_report),
+        child: Icon(Icons.bug_report, color: colorScheme.onPrimaryContainer),
       ),
     );
 

--- a/packages/leancode_debug_page/lib/src/ui/logs_inspector/logger/logger_log_details_screen/logger_log_details_screen.dart
+++ b/packages/leancode_debug_page/lib/src/ui/logs_inspector/logger/logger_log_details_screen/logger_log_details_screen.dart
@@ -5,6 +5,7 @@ import 'package:leancode_debug_page/src/ui/debug_page_route.dart';
 import 'package:leancode_debug_page/src/ui/logs_inspector/logger/level_color_extension.dart';
 import 'package:leancode_debug_page/src/ui/logs_inspector/map_view.dart';
 import 'package:leancode_debug_page/src/ui/logs_inspector/widgets/share_button.dart';
+import 'package:leancode_debug_page/src/ui/status_color_extension.dart';
 import 'package:leancode_debug_page/src/ui/typography.dart';
 import 'package:logging/logging.dart';
 import 'package:share_plus/share_plus.dart';
@@ -22,6 +23,7 @@ class LoggerLogDetailsScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final levelColor = logRecord.level.color(context);
 
     // Build the map with all available information
     final Map<Object, Object> logDetailsMap = {
@@ -98,7 +100,8 @@ class LoggerLogDetailsScreen extends StatelessWidget {
       ),
       appBar: AppBar(
         title: const Text('Logger log details'),
-        backgroundColor: logRecord.level.color(context),
+        backgroundColor: levelColor,
+        foregroundColor: levelColor.onStatusColor,
       ),
       body: ListView(padding: const EdgeInsets.all(24), children: widgets),
     );

--- a/packages/leancode_debug_page/lib/src/ui/logs_inspector/logger/logger_log_tile.dart
+++ b/packages/leancode_debug_page/lib/src/ui/logs_inspector/logger/logger_log_tile.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:leancode_debug_page/src/models/log_record_format_extension.dart';
 import 'package:leancode_debug_page/src/ui/logs_inspector/logger/level_color_extension.dart';
 import 'package:leancode_debug_page/src/ui/logs_inspector/logger/logger_log_details_screen/logger_log_details_screen.dart';
+import 'package:leancode_debug_page/src/ui/status_color_extension.dart';
 import 'package:leancode_debug_page/src/ui/typography.dart';
 import 'package:logging/logging.dart';
 
@@ -12,9 +13,13 @@ class LoggerLogTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final color = log.level.color(context);
+
     return Material(
-      color: log.level.color(context),
+      color: color,
       child: ListTile(
+        textColor: color.onStatusColor,
+        iconColor: color.onStatusColor,
         onTap: () =>
             Navigator.of(context).push(LoggerLogDetailsRoute(logRecord: log)),
         title: Text(

--- a/packages/leancode_debug_page/lib/src/ui/logs_inspector/requests/request_log_tile.dart
+++ b/packages/leancode_debug_page/lib/src/ui/logs_inspector/requests/request_log_tile.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:leancode_debug_page/src/models/request_log_record.dart';
 import 'package:leancode_debug_page/src/ui/logs_inspector/requests/request_details_screen/request_details_screen.dart';
+import 'package:leancode_debug_page/src/ui/status_color_extension.dart';
 import 'package:leancode_debug_page/src/ui/typography.dart';
 
 extension _ColorExtension on RequestStatus {
@@ -44,9 +45,13 @@ class RequestLogTile extends StatelessWidget {
       url = url.substring(ignoredBasePath.length);
     }
 
+    final color = log.status.color(context);
+
     return Material(
-      color: log.status.color(context),
+      color: color,
       child: ListTile(
+        textColor: color.onStatusColor,
+        iconColor: color.onStatusColor,
         trailing: Text(
           log.statusCode.toString(),
           style: DebugPageTypography.small,

--- a/packages/leancode_debug_page/lib/src/ui/status_color_extension.dart
+++ b/packages/leancode_debug_page/lib/src/ui/status_color_extension.dart
@@ -1,0 +1,16 @@
+import 'dart:ui';
+
+import 'package:flutter/material.dart' show Colors, ThemeData;
+
+extension StatusColorExtension on Color {
+  /// A foreground legible on a surface painted with this color.
+  ///
+  /// The debug page paints tiles and app bars with its own status colors, which
+  /// the app's theme knows nothing about, so its `onSurface` cannot be trusted
+  /// on them. [ThemeData.estimateBrightnessForColor] answers a different
+  /// question - it reads mid tones like [Colors.green] as dark and would put
+  /// white on them at 2.8:1 - so compare against the luminance where black and
+  /// white contrast equally, `sqrt(1.05 * 0.05) - 0.05` per WCAG.
+  Color get onStatusColor =>
+      computeLuminance() > 0.179 ? Colors.black : Colors.white;
+}

--- a/packages/leancode_debug_page/lib/src/ui/status_color_extension.dart
+++ b/packages/leancode_debug_page/lib/src/ui/status_color_extension.dart
@@ -1,4 +1,14 @@
+import 'dart:math';
+
 import 'package:flutter/material.dart';
+
+/// The luminance at which black and white contrast equally.
+///
+/// WCAG rates the contrast of two luminances as
+/// `(lighter + 0.05) / (darker + 0.05)`, so this solves
+/// `1.05 / (l + 0.05) == (l + 0.05) / 0.05` - the point where a foreground is
+/// no better off white than black.
+final _equalContrastLuminance = sqrt(1.05 * 0.05) - 0.05;
 
 extension StatusColorExtension on Color {
   /// A foreground legible on a surface painted with this color.
@@ -7,8 +17,8 @@ extension StatusColorExtension on Color {
   /// the app's theme knows nothing about, so its `onSurface` cannot be trusted
   /// on them. [ThemeData.estimateBrightnessForColor] answers a different
   /// question - it reads mid tones like [Colors.green] as dark and would put
-  /// white on them at 2.8:1 - so compare against the luminance where black and
-  /// white contrast equally, `sqrt(1.05 * 0.05) - 0.05` per WCAG.
-  Color get onStatusColor =>
-      computeLuminance() > 0.179 ? Colors.black : Colors.white;
+  /// white on them at 2.8:1.
+  Color get onStatusColor => computeLuminance() > _equalContrastLuminance
+      ? Colors.black
+      : Colors.white;
 }

--- a/packages/leancode_debug_page/lib/src/ui/status_color_extension.dart
+++ b/packages/leancode_debug_page/lib/src/ui/status_color_extension.dart
@@ -1,6 +1,4 @@
-import 'dart:ui';
-
-import 'package:flutter/material.dart' show Colors, ThemeData;
+import 'package:flutter/material.dart';
 
 extension StatusColorExtension on Color {
   /// A foreground legible on a surface painted with this color.

--- a/packages/leancode_debug_page/pubspec.yaml
+++ b/packages/leancode_debug_page/pubspec.yaml
@@ -1,5 +1,5 @@
 name: leancode_debug_page
-version: 3.1.2
+version: 3.1.3
 homepage: https://github.com/leancodepl/flutter_corelibrary/tree/master/packages/leancode_debug_page
 repository: https://github.com/leancodepl/flutter_corelibrary
 description: >-

--- a/packages/leancode_debug_page/test/ui/log_tile_contrast_test.dart
+++ b/packages/leancode_debug_page/test/ui/log_tile_contrast_test.dart
@@ -1,0 +1,116 @@
+import 'dart:async';
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:leancode_debug_page/src/models/request_log_record.dart';
+import 'package:leancode_debug_page/src/ui/logs_inspector/logger/logger_log_tile.dart';
+import 'package:leancode_debug_page/src/ui/logs_inspector/requests/request_log_tile.dart';
+import 'package:logging/logging.dart';
+
+void main() {
+  // The tiles paint themselves with the debug page's own status colors, so they
+  // have to stay legible under an app theme whose foreground does not contrast
+  // with those.
+  ThemeData hostileTheme(Brightness brightness) => ThemeData(
+    colorScheme: ColorScheme.fromSeed(
+      seedColor: Colors.blue,
+      brightness: brightness,
+    ).copyWith(onSurface: const Color(0xFF808080)),
+  );
+
+  double contrastRatio(Color a, Color b) {
+    final luminances = [a.computeLuminance(), b.computeLuminance()];
+
+    return (luminances.reduce(max) + 0.05) / (luminances.reduce(min) + 0.05);
+  }
+
+  Future<void> pumpTile(
+    WidgetTester tester,
+    Brightness brightness,
+    Widget tile,
+  ) => tester.pumpWidget(
+    MaterialApp(
+      theme: hostileTheme(brightness),
+      home: Scaffold(body: tile),
+    ),
+  );
+
+  void expectLegibleTexts(WidgetTester tester, Type tileType) {
+    final background = tester
+        .widget<Material>(
+          find.descendant(
+            of: find.byType(tileType),
+            matching: find.byType(Material),
+          ),
+        )
+        .color!;
+
+    final texts = find.descendant(
+      of: find.byType(tileType),
+      matching: find.byType(RichText),
+    );
+    expect(texts, findsWidgets);
+
+    for (final text in tester.widgetList<RichText>(texts)) {
+      expect(
+        contrastRatio(text.text.style!.color!, background),
+        greaterThanOrEqualTo(4.5),
+        reason: 'the text "${text.text.toPlainText()}" is illegible',
+      );
+    }
+  }
+
+  for (final brightness in Brightness.values) {
+    group('in a ${brightness.name} theme', () {
+      for (final level in const [
+        Level.FINEST,
+        Level.FINE,
+        Level.CONFIG,
+        Level.INFO,
+        Level.WARNING,
+        Level.SEVERE,
+        Level.SHOUT,
+      ]) {
+        testWidgets('a ${level.name} logger log tile is legible', (
+          tester,
+        ) async {
+          await pumpTile(
+            tester,
+            brightness,
+            LoggerLogTile(log: LogRecord(level, 'Message', 'TestLogger')),
+          );
+
+          expectLegibleTexts(tester, LoggerLogTile);
+        });
+      }
+
+      for (final statusCode in const [200, 302, 404, 500, 0]) {
+        testWidgets('a $statusCode request log tile is legible', (
+          tester,
+        ) async {
+          await pumpTile(
+            tester,
+            brightness,
+            RequestLogTile(
+              log: RequestLogRecord(
+                method: 'GET',
+                url: Uri.parse('https://example.com/resource'),
+                startTime: DateTime(2026),
+                endTime: DateTime(2026),
+                statusCode: statusCode,
+                requestHeaders: const {},
+                requestBody: null,
+                responseHeaders: const {},
+                responseBodyCompleter: Completer(),
+              ),
+              ignoredBasePath: null,
+            ),
+          );
+
+          expectLegibleTexts(tester, RequestLogTile);
+        });
+      }
+    });
+  }
+}

--- a/packages/leancode_debug_page/test/ui/log_tile_contrast_test.dart
+++ b/packages/leancode_debug_page/test/ui/log_tile_contrast_test.dart
@@ -20,9 +20,10 @@ void main() {
   );
 
   double contrastRatio(Color a, Color b) {
-    final luminances = [a.computeLuminance(), b.computeLuminance()];
+    final lumA = a.computeLuminance();
+    final lumB = b.computeLuminance();
 
-    return (luminances.reduce(max) + 0.05) / (luminances.reduce(min) + 0.05);
+    return (max(lumA, lumB) + 0.05) / (min(lumA, lumB) + 0.05);
   }
 
   Future<void> pumpTile(


### PR DESCRIPTION
The log tiles, the log details app bar and the entry button paint themselves with colors the app's theme knows nothing about, but left the text and icons on top of them to the theme's foregrounds. Derive the foreground from the painted color instead.

`ThemeData.estimateBrightnessForColor` won't do it: it reads mid tones like `Colors.green` as dark, which would put white on them at 2.8:1. The threshold here is the luminance where black and white contrast equally, so every status color gets 5.7:1 or better.