### PR TITLE
Allow analyzer 14

### DIFF
--- a/packages/leancode_lint/CHANGELOG.md
+++ b/packages/leancode_lint/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased 
+
+- Require `analyzer: '>=13.0.0 <15.0.0'`
+
 # 26.0.0
 
 - Add new custom lints:

--- a/packages/leancode_lint/CHANGELOG.md
+++ b/packages/leancode_lint/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased 
+# 26.1.0 
 
 - Require `analyzer: '>=13.0.0 <15.0.0'`
 

--- a/packages/leancode_lint/pubspec.yaml
+++ b/packages/leancode_lint/pubspec.yaml
@@ -1,5 +1,5 @@
 name: leancode_lint
-version: 26.0.0
+version: 26.1.0
 homepage: https://github.com/leancodepl/flutter_corelibrary/tree/master/packages/leancode_lint
 repository: https://github.com/leancodepl/flutter_corelibrary
 description: Robust and high-quality lint rules used at LeanCode.

--- a/packages/leancode_lint/pubspec.yaml
+++ b/packages/leancode_lint/pubspec.yaml
@@ -16,7 +16,7 @@ environment:
 
 dependencies:
   analysis_server_plugin: ^0.3.15
-  analyzer: ^13.0.0
+  analyzer: '>=13.0.0 <15.0.0'
   analyzer_plugin: ^0.14.9
   meta: ^1.18.0
   path: ^1.9.1
@@ -24,5 +24,6 @@ dependencies:
   yaml: ^3.1.3
 
 dev_dependencies:
-  analyzer_testing: ^0.2.6
+  analyzer_testing: '>=0.2.6 <4.0.0'
+  test: ^1.31.2
   test_reflective_loader: ^0.4.0


### PR DESCRIPTION
This PR ***broadens*** the allowed range for `analyzer` to still support versions 13.x — there have been no breaking changes, and many packages don't support analyzer 14 yet.

This also wins us back points on pub.dev (from the `Support up-to-date dependencies` category) – and puts us back at full 160/160.

> [!NOTE]
> I already bumped the package version to 26.1.0 instead of adding this change to an `Unreleased` section — I'll release this right after merging