### PR TITLE
Fix a false positive in `missing_equatable_props`

### DIFF
--- a/packages/leancode_lint/CHANGELOG.md
+++ b/packages/leancode_lint/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - Update [`prefer_equatable_mixin`](https://github.com/leancodepl/flutter_corelibrary/tree/master/packages/leancode_lint#prefer_equatable_mixin) to suggest mixing in `Equatable` directly when the linted package depends on `equatable` 2.1.0 or higher, where `EquatableMixin` is deprecated.
+- Update [`missing_equatable_props`](https://github.com/leancodepl/flutter_corelibrary/tree/master/packages/leancode_lint#missing_equatable_props) to not report a missing `super.props` when the superclass chain declares no fields, and so its `props` is empty.
 
 # 26.1.0
 

--- a/packages/leancode_lint/README.md
+++ b/packages/leancode_lint/README.md
@@ -1058,7 +1058,7 @@ None.
 
 ### `missing_equatable_props`
 
-**DO** include every non-static field of an `Equatable`/`EquatableMixin` class in its `props` getter. When the class extends another Equatable-shaped class whose `props` getter is concrete, `super.props` must also be referenced so inherited fields participate in equality.
+**DO** include every non-static field of an `Equatable`/`EquatableMixin` class in its `props` getter. When the class extends another Equatable-shaped class whose `props` getter is concrete, `super.props` must also be referenced so inherited fields participate in equality. `super.props` is not required when the superclass chain declares no fields, since it can only be empty.
 
 The lint only fires when `props` is defined as a list literal (e.g. `=> [a, b]` or `{ return [a, b]; }`) so it can safely reason about the contents. If the list contains expressions the rule cannot enumerate (other spreads, `if`/`for` elements, method calls, …) it silently skips the class to avoid false positives.
 

--- a/packages/leancode_lint/lib/src/lints/missing_equatable_props.dart
+++ b/packages/leancode_lint/lib/src/lints/missing_equatable_props.dart
@@ -17,8 +17,8 @@ import 'package:leancode_lint/src/utils.dart';
 ///
 /// Every non-static field declared in the class must be referenced in the
 /// `props` list literal. When the class extends another Equatable-shaped
-/// class, `super.props` must also be present so that inherited fields
-/// participate in equality.
+/// class that contributes fields of its own, `super.props` must also be
+/// present so that inherited fields participate in equality.
 class MissingEquatableProps extends AnalysisRule {
   MissingEquatableProps()
     : super(name: code.lowerCaseName, description: code.problemMessage);
@@ -247,7 +247,10 @@ List<String> _findMissingFieldNames(
 ///   `props` as abstract, so `super.props` would target the abstract member);
 /// - the superclass is an intermediate Equatable-shaped class that does not
 ///   provide a concrete `props` implementation anywhere in its chain (also
-///   making `super.props` resolve to an abstract member).
+///   making `super.props` resolve to an abstract member);
+/// - the superclass chain declares no fields, in which case `super.props` is
+///   empty and referencing it would contribute nothing (see
+///   [_hasInheritedFields]).
 bool _shouldHaveSuperProps(InterfaceElement element) {
   final supertype = element.supertype;
   if (supertype == null) {
@@ -265,6 +268,27 @@ bool _shouldHaveSuperProps(InterfaceElement element) {
     name: 'props',
     library: element.library,
   );
+  if (propsGetter == null || propsGetter.isAbstract) {
+    return false;
+  }
 
-  return propsGetter != null && !propsGetter.isAbstract;
+  return _hasInheritedFields(supertypeElement);
 }
+
+/// Whether [element] or any of its ancestors declares a field that
+/// `super.props` could contribute.
+///
+/// This rule models `props` as the list of a class's non-static fields, so a
+/// superclass chain that declares no such fields has an empty `props` and
+/// referencing `super.props` from a subclass would add nothing.
+bool _hasInheritedFields(InterfaceElement element) =>
+    [
+      element,
+      ...element.allSupertypes.map((supertype) => supertype.element),
+    ].any(
+      (ancestor) =>
+          !_equatableTypeChecker.isExactly(ancestor) &&
+          ancestor.fields.any(
+            (field) => !field.isStatic && field.isOriginDeclaration,
+          ),
+    );

--- a/packages/leancode_lint/test/test_cases/missing_equatable_props_test.dart
+++ b/packages/leancode_lint/test/test_cases/missing_equatable_props_test.dart
@@ -352,6 +352,161 @@ class Sub extends AbstractBase {
 ''');
   }
 
+  Future<void>
+  test_super_props_not_suggested_when_parent_props_is_empty() async {
+    await assertNoDiagnostics('''
+import 'package:equatable/equatable.dart';
+
+class Parent with Equatable {
+  const Parent();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class Sub extends Parent {
+  const Sub(this.a);
+
+  final int a;
+
+  @override
+  List<Object?> get props => [a];
+}
+''');
+  }
+
+  Future<void>
+  test_super_props_not_suggested_when_whole_parent_chain_has_no_fields() async {
+    await assertDiagnosticsInRanges('''
+import 'package:equatable/equatable.dart';
+
+class Base with Equatable {
+  const Base();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class Middle extends Base {
+  const Middle();
+}
+
+class Sub extends Middle {
+  const Sub(this.a, this.b);
+
+  final int a;
+  final int b;
+
+  @override
+  List<Object?> get props => [![a]!];
+}
+''');
+  }
+
+  Future<void>
+  test_super_props_suggested_when_grandparent_declares_fields() async {
+    await assertDiagnosticsInRanges('''
+import 'package:equatable/equatable.dart';
+
+class Base with Equatable {
+  const Base(this.shared);
+
+  final int shared;
+
+  @override
+  List<Object?> get props => [shared];
+}
+
+class Middle extends Base {
+  const Middle(super.shared);
+}
+
+class Sub extends Middle {
+  const Sub(super.shared, this.a);
+
+  final int a;
+
+  @override
+  List<Object?> get props => [![a]!];
+}
+''');
+  }
+
+  Future<void>
+  test_super_props_not_suggested_when_parent_only_declares_getters() async {
+    await assertNoDiagnostics('''
+import 'package:equatable/equatable.dart';
+
+class Parent with Equatable {
+  const Parent();
+
+  int get computed => 1;
+
+  @override
+  List<Object?> get props => [];
+}
+
+class Sub extends Parent {
+  const Sub(this.a);
+
+  final int a;
+
+  @override
+  List<Object?> get props => [a];
+}
+''');
+  }
+
+  Future<void>
+  test_super_props_not_suggested_when_parent_only_declares_static_fields() async {
+    await assertNoDiagnostics('''
+import 'package:equatable/equatable.dart';
+
+class Parent with Equatable {
+  const Parent();
+
+  static const int constant = 0;
+
+  @override
+  List<Object?> get props => [];
+}
+
+class Sub extends Parent {
+  const Sub(this.a);
+
+  final int a;
+
+  @override
+  List<Object?> get props => [a];
+}
+''');
+  }
+
+  Future<void>
+  test_super_props_suggested_when_parent_mixin_declares_fields() async {
+    await assertDiagnosticsInRanges('''
+import 'package:equatable/equatable.dart';
+
+mixin SharedFields {
+  final int shared = 0;
+}
+
+class Parent with Equatable, SharedFields {
+  @override
+  List<Object?> get props => [shared];
+}
+
+class Sub extends Parent {
+  Sub(this.a);
+
+  final int a;
+
+  @override
+  List<Object?> get props => [![a]!];
+}
+''');
+  }
+
   Future<void> test_unrecognized_spread_skips_lint() async {
     await assertNoDiagnostics('''
 import 'package:equatable/equatable.dart';


### PR DESCRIPTION
`missing_equatable_props` asked for `super.props` whenever the superclass exposed a
concrete `props` getter, even when that getter returns an empty list. Referencing it
there contributes nothing to equality, so the warning was noise and the quick fix
inserted a no-op entry.

The analyzer can't reach a superclass's `props` body across libraries, so the check
now leans on the rule's own model of `props` — the list of a class's non-static
fields. A superclass chain that declares no such fields necessarily has an empty
`props`, so `super.props` is only required when some ancestor between the superclass
and `Equatable` declares a field of its own. Being element-based, this behaves the
same whether the parent lives in the same file or another package.

One deliberate false negative follows: a parent with no fields but a hand-written
`props => [someGetter]` no longer gets `super.props` suggested. That matches the rule
already never requiring getters in `props`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
