### PR TITLE
[leancode_force_update] Upgrade contracts dependencies

### DIFF
--- a/packages/leancode_force_update/.config/dotnet-tools.json
+++ b/packages/leancode_force_update/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "dotnet-contracts-generate": {
-      "version": "4.0.0",
+      "version": "4.1.0",
       "commands": [
         "dotnet-contracts-generate"
       ],

--- a/packages/leancode_force_update/CHANGELOG.md
+++ b/packages/leancode_force_update/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.0.4-alpha
+
+- Upgrade `leancode_contracts` dependency to `^0.10.0`
+- Upgrade `leancode_contracts_generator` dev dependency to `^0.19.0`
+- Upgrade `leancode_lint` dev dependency to `^19.0.0`
+- Upgrade `dotnet-contracts-generate` to `4.1.0`
+- Regenerate contracts
+
 ## 1.0.3-alpha
 
 - Upgrade `leancode_contracts` dependency to `^0.9.0`

--- a/packages/leancode_force_update/CHANGELOG.md
+++ b/packages/leancode_force_update/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Upgrade `leancode_contracts_generator` dev dependency to `^0.19.0`
 - Upgrade `leancode_lint` dev dependency to `^19.0.0`
 - Upgrade `dotnet-contracts-generate` to `4.1.0`
+- Drop the `json_serializable` dev dependency, no longer used for generating contracts serialization
 - Regenerate contracts
 
 ## 1.0.3-alpha

--- a/packages/leancode_force_update/CHANGELOG.md
+++ b/packages/leancode_force_update/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 - Upgrade `leancode_contracts` to `^0.10.0` and `leancode_contracts_generator` to `^0.19.0`
 - Drop the now-unused `json_serializable` dev dependency
-- Regenerate contracts
 
 ## 1.0.3-alpha
 

--- a/packages/leancode_force_update/CHANGELOG.md
+++ b/packages/leancode_force_update/CHANGELOG.md
@@ -1,10 +1,7 @@
 ## 1.0.4-alpha
 
-- Upgrade `leancode_contracts` dependency to `^0.10.0`
-- Upgrade `leancode_contracts_generator` dev dependency to `^0.19.0`
-- Upgrade `leancode_lint` dev dependency to `^19.0.0`
-- Upgrade `dotnet-contracts-generate` to `4.1.0`
-- Drop the `json_serializable` dev dependency, no longer used for generating contracts serialization
+- Upgrade `leancode_contracts` to `^0.10.0` and `leancode_contracts_generator` to `^0.19.0`
+- Drop the now-unused `json_serializable` dev dependency
 - Regenerate contracts
 
 ## 1.0.3-alpha

--- a/packages/leancode_force_update/example/pubspec.lock
+++ b/packages/leancode_force_update/example/pubspec.lock
@@ -316,17 +316,17 @@ packages:
     dependency: transitive
     description:
       name: leancode_contracts
-      sha256: "1acf05253c522134ddda25a46b31adaf4b5756714e97f5fff0e29437fd4dce87"
+      sha256: "0b1be413e36b26e9d4016cfd01d64616ac78a6de613d212a964ede6626de8ea1"
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.0"
+    version: "0.10.0"
   leancode_force_update:
     dependency: "direct main"
     description:
       path: ".."
       relative: true
     source: path
-    version: "1.0.2-alpha"
+    version: "1.0.4-alpha"
   leancode_lint:
     dependency: "direct dev"
     description:

--- a/packages/leancode_force_update/lib/data/contracts/contracts.g.dart
+++ b/packages/leancode_force_update/lib/data/contracts/contracts.g.dart
@@ -3,7 +3,7 @@
 part of 'contracts.dart';
 
 // **************************************************************************
-// JsonSerializableGenerator
+// ContractsSerializableGenerator
 // **************************************************************************
 
 VersionSupport _$VersionSupportFromJson(Map<String, dynamic> json) =>

--- a/packages/leancode_force_update/pubspec.yaml
+++ b/packages/leancode_force_update/pubspec.yaml
@@ -24,7 +24,6 @@ dev_dependencies:
   build_runner: ^2.7.1
   flutter_test:
     sdk: flutter
-  json_serializable: ^6.11.2
   leancode_contracts_generator: ^0.19.0
   leancode_lint: ^19.0.0
   mocktail: ^1.0.4

--- a/packages/leancode_force_update/pubspec.yaml
+++ b/packages/leancode_force_update/pubspec.yaml
@@ -1,5 +1,5 @@
 name: leancode_force_update
-version: 1.0.3-alpha
+version: 1.0.4-alpha
 homepage: https://github.com/leancodepl/flutter_corelibrary/tree/master/packages/leancode_force_update
 repository: https://github.com/leancodepl/flutter_corelibrary
 description: An internal package that speeds up implementation of Force Update
@@ -13,7 +13,7 @@ dependencies:
   flutter:
     sdk: flutter
   in_app_update: ^4.2.3
-  leancode_contracts: ^0.9.0
+  leancode_contracts: ^0.10.0
   logging: ^1.3.0
   package_info_plus: ^10.2.0
   shared_preferences: ^2.5.3
@@ -25,6 +25,6 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   json_serializable: ^6.11.2
-  leancode_contracts_generator: ^0.18.0
-  leancode_lint: ^17.0.0
+  leancode_contracts_generator: ^0.19.0
+  leancode_lint: ^19.0.0
   mocktail: ^1.0.4


### PR DESCRIPTION
Upgrades the contracts toolchain in `leancode_force_update` and regenerates the contracts.

## Changes

- `leancode_contracts` `^0.9.0` → `^0.10.0`
- `leancode_contracts_generator` `^0.18.0` → `^0.19.0`
- `dotnet-contracts-generate` (`.config/dotnet-tools.json`) `4.0.0` → `4.1.0`
- `leancode_lint` `^17.0.0` → `^19.0.0` — forced by the above: lint 17/18 pin `analyzer ^7.3.0` while the new generator needs `analyzer >=8.1.1`, so version solving failed otherwise. 19.0.x is the lowest version that resolves while keeping the package's `sdk: >=3.10.0` floor (lint ≥20 would require bumping the SDK/Flutter constraints and the CI matrix).
- Dropped the `json_serializable` dev dependency — generator v0.19.0 generates serialization with its own `contracts_serializable` builder, so the `json_serializable` builder had become a no-op here. It remains in the lockfile as a transitive dependency of the generator. `build_runner` stays, since it drives the new builder.
- Version bumped to `1.0.4-alpha` (`1.0.3-alpha` is already published), with a CHANGELOG entry.

`Leancode.ForceUpdate.Contracts` is left at `10.0.2860` — already the newest published version.

## Regenerated output

`contracts.dart` is unchanged. The only change in `contracts.g.dart` is the generator header:

```diff
-// JsonSerializableGenerator
+// ContractsSerializableGenerator
```

The `fromJson`/`toJson` bodies are byte-identical, both across the generator upgrade and across the `dotnet-contracts-generate` bump.

## Verification

Ran locally against Flutter 3.44.9 stable and .NET SDK 8:

- Confirmed the pre-upgrade toolchain reproduced the committed generated files byte-for-byte before changing anything, to validate the setup.
- `flutter analyze` — no issues
- `flutter test` — 8/8 passing
- `flutter pub publish --dry-run` — clean apart from the usual "not an incremental update" hint that the `-alpha` versioning scheme has always produced


---
_Generated by [Claude Code](https://claude.ai/code/session_01CwSEMS3JeqqcupWaZcS18h)_