### PR TITLE
[leancode_analytics_posthog] Send one $screen event per navigation

### DIFF
--- a/packages/leancode_analytics_posthog/CHANGELOG.md
+++ b/packages/leancode_analytics_posthog/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.1
+
+- Fix `LeanAnalyticsPostHogObserver` sending two `$screen` events per navigation
+
 ## 0.1.0
 
 - Initial release with PostHog Analytics implementation

--- a/packages/leancode_analytics_posthog/lib/src/posthog_analytics_observer.dart
+++ b/packages/leancode_analytics_posthog/lib/src/posthog_analytics_observer.dart
@@ -5,6 +5,11 @@ import 'package:posthog_flutter/posthog_flutter.dart';
 /// PostHog observer that tracks screen views for routes implementing
 /// [LeanAnalyticsRoute].
 class LeanAnalyticsPostHogObserver extends PosthogObserver {
+  /// Screen views come from [_sendLeanAnalyticsScreen]. Suppressing the
+  /// inherited ones keeps [PosthogObserver]'s bookkeeping while stopping it from
+  /// sending a second `$screen` named after `RouteSettings.name`.
+  LeanAnalyticsPostHogObserver() : super(nameExtractor: (_) => null);
+
   @override
   void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
     if (route is LeanAnalyticsRoute) {

--- a/packages/leancode_analytics_posthog/lib/src/posthog_analytics_observer.dart
+++ b/packages/leancode_analytics_posthog/lib/src/posthog_analytics_observer.dart
@@ -5,9 +5,7 @@ import 'package:posthog_flutter/posthog_flutter.dart';
 /// PostHog observer that tracks screen views for routes implementing
 /// [LeanAnalyticsRoute].
 class LeanAnalyticsPostHogObserver extends PosthogObserver {
-  /// Screen views come from [_sendLeanAnalyticsScreen]. Suppressing the
-  /// inherited ones keeps [PosthogObserver]'s bookkeeping while stopping it from
-  /// sending a second `$screen` named after `RouteSettings.name`.
+  /// Creates an observer that sends screen views for [LeanAnalyticsRoute]s only.
   LeanAnalyticsPostHogObserver() : super(nameExtractor: (_) => null);
 
   @override

--- a/packages/leancode_analytics_posthog/pubspec.yaml
+++ b/packages/leancode_analytics_posthog/pubspec.yaml
@@ -1,6 +1,6 @@
 name: leancode_analytics_posthog
 description: PostHog Analytics implementation for LeanCode analytics.
-version: 0.1.0+1
+version: 0.1.1
 homepage: https://github.com/leancodepl/flutter_corelibrary/tree/master/packages/leancode_analytics_posthog
 repository: https://github.com/leancodepl/flutter_corelibrary
 


### PR DESCRIPTION
⚠️  - 🤖 AI fix for sth that came out in new project made from template

## Problem

`LeanAnalyticsPostHogObserver` sends a `$screen` for the `LeanAnalyticsRoute` id, then calls `super`,
which makes `PosthogObserver` send a second one named after `RouteSettings.name`.

One navigation, two events, two naming schemes — in an auto_route app that's `loginPage` and
`LoginRoute` for the same push. Screen view counts come out doubled and split across both names.

It only surfaces when routes carry a non-empty `RouteSettings.name`; `PosthogObserver` skips the
rest, which is why the package can look fine in projects that don't name their routes.

## Fix

Pass a `nameExtractor` that returns `null`, so the inherited screen view is suppressed while
`PosthogObserver`'s own bookkeeping — survey context, route subscriptions — still runs.

Routes that don't implement `LeanAnalyticsRoute` stop being tracked, which is what the class already
documents.
