### PR TITLE
[leancode_lint] Handle Dart 3.13 primary constructors

### DIFF
--- a/packages/leancode_lint/CHANGELOG.md
+++ b/packages/leancode_lint/CHANGELOG.md
@@ -1,3 +1,12 @@
+# Unreleased
+
+- Support Dart 3.13 primary constructors:
+  - [`missing_equatable_props`](https://github.com/leancodepl/flutter_corelibrary/tree/master/packages/leancode_lint#missing_equatable_props) now requires fields declared by a primary constructor's declaring parameters to be listed in `props`, and recognizes `super.props` as needed when the superclass declares its fields in a primary constructor.
+  - [`constructor_parameters_and_fields_should_have_the_same_order`](https://github.com/leancodepl/flutter_corelibrary/tree/master/packages/leancode_lint#constructor_parameters_and_fields_should_have_the_same_order) now treats fields declared by a primary constructor as coming before the fields declared in the class body.
+  - [`avoid_build_context_in_blocs`](https://github.com/leancodepl/flutter_corelibrary/tree/master/packages/leancode_lint#avoid_build_context_in_blocs) now reports `BuildContext` parameters declared in a Bloc/Cubit's primary constructor.
+  - [`prefer_abstract_final_class`](https://github.com/leancodepl/flutter_corelibrary/tree/master/packages/leancode_lint#prefer_abstract_final_class) now recognizes a private `._()` primary constructor as an instantiation guard, and its fix removes it from the class header.
+  - The "convert to a named formal parameter" assist now preserves the parameter's own declaration (e.g. a primary constructor's declaring `final int x` or a `super.x` parameter) instead of always producing `this.`-prefixed parameters.
+
 # 26.2.0
 
 - Update [`prefer_equatable_mixin`](https://github.com/leancodepl/flutter_corelibrary/tree/master/packages/leancode_lint#prefer_equatable_mixin) to suggest mixing in `Equatable` directly when the linted package depends on `equatable` 2.1.0 or higher, where `EquatableMixin` is deprecated.

--- a/packages/leancode_lint/lib/src/assists/convert_positional_to_named_formal.dart
+++ b/packages/leancode_lint/lib/src/assists/convert_positional_to_named_formal.dart
@@ -87,8 +87,11 @@ class ConvertPositionalToNamedFormal extends ResolvedCorrectionProducer {
         // delete positional parameter
         builder.addDeletion(sourceRange);
 
+        // Keep the parameter's own declaration (`this.x`, `super.x`, or a
+        // primary constructor's declaring `final int x`) instead of
+        // synthesizing a `this.`-prefixed one.
         final namedParam =
-            '${Keyword.REQUIRED.lexeme} ${Keyword.THIS.lexeme}.${parameter.name},';
+            '${Keyword.REQUIRED.lexeme} ${parameter.toSource()},';
 
         if (node.leftDelimiter case final brace?) {
           // has named parameters, add to list

--- a/packages/leancode_lint/lib/src/lints/avoid_build_context_in_blocs.dart
+++ b/packages/leancode_lint/lib/src/lints/avoid_build_context_in_blocs.dart
@@ -85,6 +85,12 @@ class _Visitor extends SimpleAstVisitor<void> {
       return;
     }
 
+    if (node.namePart case PrimaryConstructorDeclaration(
+      :final formalParameters,
+    )) {
+      _checkParameters(formalParameters, blocType);
+    }
+
     final members = switch (node.body) {
       BlockClassBody(:final members) => members,
       _ => const <ClassMember>[],

--- a/packages/leancode_lint/lib/src/lints/constructor_parameters_and_fields_should_have_the_same_order.dart
+++ b/packages/leancode_lint/lib/src/lints/constructor_parameters_and_fields_should_have_the_same_order.dart
@@ -44,23 +44,38 @@ class _Visitor extends SimpleAstVisitor<void> {
       _ => <ClassMember>[],
     };
 
-    final fields = members.whereType<FieldDeclaration>().toList();
+    // Fields introduced by the primary constructor's declaring formal
+    // parameters come before the fields declared in the class body.
+    final fieldNames = [
+      ..._primaryConstructorFieldNames(node),
+      for (final field in members.whereType<FieldDeclaration>())
+        _effectiveName(field.fields.variables.first.name.lexeme),
+    ];
 
-    if (fields.isEmpty) {
+    if (fieldNames.isEmpty) {
       return;
     }
 
     final constructors = members.whereType<ConstructorDeclaration>();
     for (final constructor in constructors) {
-      if (!_hasValidOrder(constructor, fields)) {
+      if (!_hasValidOrder(constructor, fieldNames)) {
         rule.reportAtNode(constructor);
       }
     }
   }
 
+  List<String> _primaryConstructorFieldNames(ClassDeclaration node) => [
+    if (node.namePart case PrimaryConstructorDeclaration(
+      :final formalParameters,
+    ))
+      for (final parameter in formalParameters.parameters)
+        if (parameter.declaredFragment?.element is FieldFormalParameterElement)
+          if (parameter.name case final name?) _effectiveName(name.lexeme),
+  ];
+
   bool _hasValidOrder(
     ConstructorDeclaration constructor,
-    List<FieldDeclaration> fields,
+    List<String> fieldNames,
   ) {
     final parameters = constructor.parameters.parameters;
     if (parameters.isEmpty) {
@@ -77,7 +92,7 @@ class _Visitor extends SimpleAstVisitor<void> {
         )
         .toList();
 
-    final fieldsWithNamedParameters = fields
+    final fieldsWithNamedParameters = fieldNames
         .where(
           (field) => namedParameters.any(
             (parameter) => _compareEffectiveNames(field, parameter),
@@ -85,7 +100,7 @@ class _Visitor extends SimpleAstVisitor<void> {
         )
         .toList();
 
-    final fieldsWithUnnamedParameters = fields
+    final fieldsWithUnnamedParameters = fieldNames
         .where(
           (field) => unnamedParameters.any(
             (parameter) => _compareEffectiveNames(field, parameter),
@@ -126,20 +141,17 @@ class _Visitor extends SimpleAstVisitor<void> {
       parameter.declaredFragment?.element is! SuperFormalParameterElement;
 
   bool _compareEffectiveNames(
-    FieldDeclaration field,
+    String effectiveFieldName,
     FormalParameter parameter,
   ) {
-    final relevantField = field.fields.variables.first;
-
-    final effectiveFieldName = relevantField.name.lexeme.startsWith('_')
-        ? relevantField.name.lexeme.substring(1)
-        : relevantField.name.lexeme;
-
-    final effectiveParameterName =
-        parameter.name?.lexeme.startsWith('_') ?? false
-        ? parameter.name?.lexeme.substring(1)
-        : parameter.name?.lexeme;
+    final effectiveParameterName = switch (parameter.name?.lexeme) {
+      final name? => _effectiveName(name),
+      null => null,
+    };
 
     return effectiveParameterName == effectiveFieldName;
   }
+
+  static String _effectiveName(String name) =>
+      name.startsWith('_') ? name.substring(1) : name;
 }

--- a/packages/leancode_lint/lib/src/lints/missing_equatable_props.dart
+++ b/packages/leancode_lint/lib/src/lints/missing_equatable_props.dart
@@ -77,7 +77,7 @@ class _Visitor extends SimpleAstVisitor<void> {
 
     final missing = _findMissingPropEntries(
       element: element,
-      members: members,
+      node: node,
       contents: contents,
     );
     if (missing.isEmpty) {
@@ -117,7 +117,10 @@ class AddToEquatablePropsFix extends ResolvedCorrectionProducer {
 
     final needsSuper =
         _shouldHaveSuperProps(element) && !contents.hasSuperPropsReference;
-    final missingFields = _findMissingFieldNames(members, contents.names);
+    final missingFields = _findMissingFieldNames(
+      classDeclaration,
+      contents.names,
+    );
 
     await builder.addDartFileEdit(file, (builder) {
       if (listLiteral.elements.isEmpty) {
@@ -215,7 +218,7 @@ _PropsListContents _collectExistingProps(ListLiteral listLiteral) {
 
 List<String> _findMissingPropEntries({
   required InterfaceElement element,
-  required List<ClassMember> members,
+  required ClassDeclaration node,
   required _PropsListContents contents,
 }) {
   final needsSuper =
@@ -223,18 +226,35 @@ List<String> _findMissingPropEntries({
 
   return [
     if (needsSuper) 'super.props',
-    ..._findMissingFieldNames(members, contents.names),
+    ..._findMissingFieldNames(node, contents.names),
   ];
 }
 
 List<String> _findMissingFieldNames(
-  List<ClassMember> members,
+  ClassDeclaration node,
   Set<String> existingNames,
 ) => [
-  for (final fieldDeclaration in members.whereType<FieldDeclaration>())
+  for (final name in _primaryConstructorFieldNames(node))
+    if (!existingNames.contains(name)) name,
+  for (final fieldDeclaration in _getMembers(
+    node,
+  ).whereType<FieldDeclaration>())
     if (!fieldDeclaration.isStatic)
       for (final variable in fieldDeclaration.fields.variables)
         if (!existingNames.contains(variable.name.lexeme)) variable.name.lexeme,
+];
+
+/// Names of the fields introduced by the primary constructor's declaring
+/// formal parameters (`final`/`var` parameters in the class header), in
+/// declaration order.
+List<String> _primaryConstructorFieldNames(ClassDeclaration node) => [
+  if (node.namePart case PrimaryConstructorDeclaration(:final formalParameters))
+    for (final parameter in formalParameters.parameters)
+      if (parameter.declaredFragment?.element case FieldFormalParameterElement(
+        isDeclaring: true,
+        field: FieldElement(:final name?),
+      ))
+        name,
 ];
 
 /// Whether the class's superclass exposes a concrete `props` getter that
@@ -289,6 +309,9 @@ bool _hasInheritedFields(InterfaceElement element) =>
       (ancestor) =>
           !_equatableTypeChecker.isExactly(ancestor) &&
           ancestor.fields.any(
-            (field) => !field.isStatic && field.isOriginDeclaration,
+            (field) =>
+                !field.isStatic &&
+                (field.isOriginDeclaration ||
+                    field.isOriginDeclaringFormalParameter),
           ),
     );

--- a/packages/leancode_lint/lib/src/lints/prefer_abstract_final_class.dart
+++ b/packages/leancode_lint/lib/src/lints/prefer_abstract_final_class.dart
@@ -6,6 +6,7 @@ import 'package:analyzer/analysis_rule/rule_visitor_registry.dart';
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/error/error.dart';
+import 'package:analyzer/source/source_range.dart';
 import 'package:analyzer_plugin/utilities/change_builder/change_builder_core.dart';
 import 'package:analyzer_plugin/utilities/fixes/fixes.dart';
 import 'package:analyzer_plugin/utilities/range_factory.dart';
@@ -66,14 +67,20 @@ class _Visitor extends SimpleAstVisitor<void> {
       return;
     }
 
-    // A primary constructor declares an additional constructor, so the class is
-    // not a simple static holder.
-    if (node.namePart is! NameWithTypeParameters) {
+    // A primary constructor is a guard only when it is the private `._()`;
+    // anything else means the class is meant to be instantiated.
+    final primaryConstructor = switch (node.namePart) {
+      final PrimaryConstructorDeclaration primaryConstructor =>
+        primaryConstructor,
+      _ => null,
+    };
+    if (primaryConstructor != null &&
+        !_isPrimaryInstantiationGuard(primaryConstructor)) {
       return;
     }
 
     ConstructorDeclaration? theConstructor;
-    var constructorCount = 0;
+    var constructorCount = primaryConstructor != null ? 1 : 0;
     var staticMemberCount = 0;
 
     for (final member in node.body.members) {
@@ -86,8 +93,9 @@ class _Visitor extends SimpleAstVisitor<void> {
           staticMemberCount++;
         default:
           // Any instance member (field, method, getter, setter, operator) or
-          // any other unexpected member means this is not a pure static
-          // holder. Bail out to avoid false positives.
+          // any other unexpected member (including a primary constructor
+          // `this` body) means this is not a pure static holder. Bail out to
+          // avoid false positives.
           return;
       }
     }
@@ -95,9 +103,10 @@ class _Visitor extends SimpleAstVisitor<void> {
     // Fire only when there is exactly one constructor, it is the private
     // instantiation-guard `_()`, and the class exposes at least one static
     // member (otherwise the transformation is pointless).
-    if (constructorCount != 1 ||
-        staticMemberCount == 0 ||
-        !_isInstantiationGuard(theConstructor!)) {
+    if (constructorCount != 1 || staticMemberCount == 0) {
+      return;
+    }
+    if (theConstructor != null && !_isInstantiationGuard(theConstructor)) {
       return;
     }
 
@@ -134,6 +143,15 @@ class _Visitor extends SimpleAstVisitor<void> {
       _ => false,
     };
   }
+
+  /// Whether [primaryConstructor] is a private `._()` primary constructor
+  /// without parameters, serving only to prevent instantiation. A `this` body
+  /// member (initializers or a body block) is rejected by the member loop.
+  static bool _isPrimaryInstantiationGuard(
+    PrimaryConstructorDeclaration primaryConstructor,
+  ) =>
+      primaryConstructor.constructorName?.name.lexeme == '_' &&
+      primaryConstructor.formalParameters.parameters.isEmpty;
 }
 
 class ConvertToAbstractFinalClass extends ResolvedCorrectionProducer {
@@ -156,20 +174,36 @@ class ConvertToAbstractFinalClass extends ResolvedCorrectionProducer {
       return;
     }
 
-    final constructor = classDeclaration.body.members
-        .whereType<ConstructorDeclaration>()
-        .firstOrNull;
-    if (constructor == null) {
-      return;
+    final List<SourceRange> deletions;
+    switch (classDeclaration.namePart) {
+      case PrimaryConstructorDeclaration(
+        :final constKeyword,
+        :final typeName,
+        :final constructorName?,
+        :final formalParameters,
+      ):
+        deletions = [
+          if (constKeyword != null) range.startStart(constKeyword, typeName),
+          range.startEnd(constructorName, formalParameters),
+        ];
+      case PrimaryConstructorDeclaration():
+        return;
+      case NameWithTypeParameters():
+        final constructor = classDeclaration.body.members
+            .whereType<ConstructorDeclaration>()
+            .firstOrNull;
+        if (constructor == null) {
+          return;
+        }
+        deletions = [range.deletionRange(constructor)];
     }
 
     await builder.addDartFileEdit(file, (builder) {
-      builder
-        ..addSimpleInsertion(
-          classDeclaration.classKeyword.offset,
-          'abstract final ',
-        )
-        ..addDeletion(range.deletionRange(constructor));
+      builder.addSimpleInsertion(
+        classDeclaration.classKeyword.offset,
+        'abstract final ',
+      );
+      deletions.forEach(builder.addDeletion);
     });
   }
 }

--- a/packages/leancode_lint/test/test_cases/add_cubit_suffix_for_cubits_test.dart
+++ b/packages/leancode_lint/test/test_cases/add_cubit_suffix_for_cubits_test.dart
@@ -46,4 +46,18 @@ class /*[2*/ClassExtendingOtherCubitClassWithoutSuffix/*2]*/ extends NotProperly
 }
 ''');
   }
+
+  Future<void> test_primary_constructor() async {
+    await assertDiagnosticsInRanges('''
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+class ProperlyNamedCubit(final int start) extends Cubit<int> {
+  this : super(start);
+}
+
+class /*[0*/NotProperlyNamed/*0]*/(final int start) extends Cubit<int> {
+  this : super(start);
+}
+''');
+  }
 }

--- a/packages/leancode_lint/test/test_cases/add_cubit_suffix_for_cubits_test.dart
+++ b/packages/leancode_lint/test/test_cases/add_cubit_suffix_for_cubits_test.dart
@@ -55,7 +55,7 @@ class ProperlyNamedCubit(final int start) extends Cubit<int> {
   this : super(start);
 }
 
-class /*[0*/NotProperlyNamed/*0]*/(final int start) extends Cubit<int> {
+class [!NotProperlyNamed!](final int start) extends Cubit<int> {
   this : super(start);
 }
 ''');

--- a/packages/leancode_lint/test/test_cases/avoid_build_context_in_blocs_test.dart
+++ b/packages/leancode_lint/test/test_cases/avoid_build_context_in_blocs_test.dart
@@ -355,4 +355,36 @@ void f(NotABloc notABloc, BuildContext context) {
 }
 ''');
   }
+
+  Future<void> test_contextParameterInPrimaryConstructor_flagged() async {
+    await assertDiagnosticsInRanges('''
+import 'package:flutter/material.dart';
+import 'package:bloc/bloc.dart';
+
+class CounterCubit(BuildContext [!context!]) extends Cubit<int> {
+  this : super(0);
+}
+''');
+  }
+
+  Future<void> test_contextFieldDeclaredInPrimaryConstructor_flagged() async {
+    await assertDiagnosticsInRanges('''
+import 'package:flutter/material.dart';
+import 'package:bloc/bloc.dart';
+
+class CounterCubit(final BuildContext [!context!]) extends Cubit<int> {
+  this : super(0);
+}
+''');
+  }
+
+  Future<void> test_primaryConstructorWithoutContext_ok() async {
+    await assertNoDiagnostics('''
+import 'package:bloc/bloc.dart';
+
+class CounterCubit(final int start) extends Cubit<int> {
+  this : super(start);
+}
+''');
+  }
 }

--- a/packages/leancode_lint/test/test_cases/constructor_parameters_and_fields_should_have_the_same_order_test.dart
+++ b/packages/leancode_lint/test/test_cases/constructor_parameters_and_fields_should_have_the_same_order_test.dart
@@ -386,7 +386,7 @@ class Point(final int first, final int second) {
   test_redirecting_constructor_violating_primary_constructor_field_order() async {
     await assertDiagnosticsInRanges('''
 class Point(final int first, final int second) {
-  /*[0*/Point.flipped(int second, int first) : this(first, second);/*0]*/
+  [!Point.flipped(int second, int first) : this(first, second);!]
 }
 ''');
   }
@@ -394,8 +394,8 @@ class Point(final int first, final int second) {
   Future<void> test_primary_constructor_fields_precede_body_fields() async {
     await assertDiagnosticsInRanges('''
 class Point(final int first) {
-  /*[0*/factory Point.reversed(int second, int first) =>
-      Point(first)..second = second;/*0]*/
+  [!factory Point.reversed(int second, int first) =>
+      Point(first)..second = second;!]
 
   int second = 0;
 }

--- a/packages/leancode_lint/test/test_cases/constructor_parameters_and_fields_should_have_the_same_order_test.dart
+++ b/packages/leancode_lint/test/test_cases/constructor_parameters_and_fields_should_have_the_same_order_test.dart
@@ -366,4 +366,60 @@ class ClassWithValidOrderButOneFieldIsNullableAndMutable {
 }
 ''');
   }
+
+  Future<void> test_primary_constructor_alone_is_not_reported() async {
+    await assertNoDiagnostics('''
+class Point(final int first, final int second);
+''');
+  }
+
+  Future<void>
+  test_redirecting_constructor_matching_primary_constructor_field_order() async {
+    await assertNoDiagnostics('''
+class Point(final int first, final int second) {
+  Point.flipped(int first, int second) : this(second, first);
+}
+''');
+  }
+
+  Future<void>
+  test_redirecting_constructor_violating_primary_constructor_field_order() async {
+    await assertDiagnosticsInRanges('''
+class Point(final int first, final int second) {
+  /*[0*/Point.flipped(int second, int first) : this(first, second);/*0]*/
+}
+''');
+  }
+
+  Future<void> test_primary_constructor_fields_precede_body_fields() async {
+    await assertDiagnosticsInRanges('''
+class Point(final int first) {
+  /*[0*/factory Point.reversed(int second, int first) =>
+      Point(first)..second = second;/*0]*/
+
+  int second = 0;
+}
+''');
+  }
+
+  Future<void>
+  test_primary_constructor_fields_precede_body_fields_valid_order() async {
+    await assertNoDiagnostics('''
+class Point(final int first) {
+  factory Point.ordered(int first, int second) =>
+      Point(first)..second = second;
+
+  int second = 0;
+}
+''');
+  }
+
+  Future<void>
+  test_non_declaring_primary_constructor_parameters_are_not_fields() async {
+    await assertNoDiagnostics('''
+class Point(int scale, final int first) {
+  Point.other(int first, int scale) : this(scale, first);
+}
+''');
+  }
 }

--- a/packages/leancode_lint/test/test_cases/missing_equatable_props_test.dart
+++ b/packages/leancode_lint/test/test_cases/missing_equatable_props_test.dart
@@ -542,4 +542,103 @@ class MyState with Equatable {
 }
 ''');
   }
+
+  Future<void> test_primary_constructor_all_fields_present() async {
+    await assertNoDiagnostics('''
+import 'package:equatable/equatable.dart';
+
+class MyState(final int a, final String b) with Equatable {
+  @override
+  List<Object?> get props => [a, b];
+}
+''');
+  }
+
+  Future<void> test_primary_constructor_missing_fields() async {
+    await assertDiagnosticsInRanges(
+      '''
+import 'package:equatable/equatable.dart';
+
+class MyState(final int a, final int b, final int c) with Equatable {
+  @override
+  List<Object?> get props => /*[0*/[a]/*0]*/;
+}
+''',
+      messageContainsAll: [
+        ['b, c'],
+      ],
+    );
+  }
+
+  Future<void> test_primary_constructor_var_declaring_parameter() async {
+    await assertDiagnosticsInRanges(
+      '''
+import 'package:equatable/equatable.dart';
+
+class MyState(final int a, var int b) with Equatable {
+  @override
+  List<Object?> get props => /*[0*/[a]/*0]*/;
+}
+''',
+      messageContainsAll: [
+        ['b'],
+      ],
+    );
+  }
+
+  Future<void>
+  test_primary_constructor_non_declaring_parameters_ignored() async {
+    await assertNoDiagnostics('''
+import 'package:equatable/equatable.dart';
+
+class MyState(final int a, int b) with Equatable {
+  @override
+  List<Object?> get props => [a];
+}
+''');
+  }
+
+  Future<void> test_primary_constructor_and_body_fields_both_required() async {
+    await assertDiagnosticsInRanges(
+      '''
+import 'package:equatable/equatable.dart';
+
+class MyState(final int a) with Equatable {
+  final int b = 0;
+
+  @override
+  List<Object?> get props => /*[0*/[]/*0]*/;
+}
+''',
+      messageContainsAll: [
+        ['a, b'],
+      ],
+    );
+  }
+
+  Future<void>
+  test_super_props_required_when_parent_declares_fields_in_primary_constructor() async {
+    await assertDiagnosticsInRanges(
+      '''
+import 'package:equatable/equatable.dart';
+
+class Parent(final int a) with Equatable {
+  @override
+  List<Object?> get props => [a];
+}
+
+class Sub extends Parent {
+  Sub(super.a, this.b);
+
+  final int b;
+
+  @override
+  List<Object?> get props => /*[0*/[b]/*0]*/;
+}
+''',
+      messageContainsAll: [
+        ['super.props'],
+      ],
+    );
+  }
 }

--- a/packages/leancode_lint/test/test_cases/missing_equatable_props_test.dart
+++ b/packages/leancode_lint/test/test_cases/missing_equatable_props_test.dart
@@ -561,7 +561,7 @@ import 'package:equatable/equatable.dart';
 
 class MyState(final int a, final int b, final int c) with Equatable {
   @override
-  List<Object?> get props => /*[0*/[a]/*0]*/;
+  List<Object?> get props => [![a]!];
 }
 ''',
       messageContainsAll: [
@@ -577,7 +577,7 @@ import 'package:equatable/equatable.dart';
 
 class MyState(final int a, var int b) with Equatable {
   @override
-  List<Object?> get props => /*[0*/[a]/*0]*/;
+  List<Object?> get props => [![a]!];
 }
 ''',
       messageContainsAll: [
@@ -607,7 +607,7 @@ class MyState(final int a) with Equatable {
   final int b = 0;
 
   @override
-  List<Object?> get props => /*[0*/[]/*0]*/;
+  List<Object?> get props => [![]!];
 }
 ''',
       messageContainsAll: [
@@ -633,7 +633,7 @@ class Sub extends Parent {
   final int b;
 
   @override
-  List<Object?> get props => /*[0*/[b]/*0]*/;
+  List<Object?> get props => [![b]!];
 }
 ''',
       messageContainsAll: [

--- a/packages/leancode_lint/test/test_cases/prefer_abstract_final_class_test.dart
+++ b/packages/leancode_lint/test/test_cases/prefer_abstract_final_class_test.dart
@@ -242,4 +242,59 @@ mixin MyMixin {
 }
 ''');
   }
+
+  Future<void> test_private_primary_constructor_guard_is_marked() async {
+    await assertDiagnosticsInRanges('''
+class [!MyConstants!]._() {
+  static const foo = 1;
+}
+''');
+  }
+
+  Future<void> test_const_private_primary_constructor_guard_is_marked() async {
+    await assertDiagnosticsInRanges('''
+class const [!MyConstants!]._() {
+  static const foo = 1;
+}
+''');
+  }
+
+  Future<void> test_unnamed_primary_constructor_is_not_marked() async {
+    await assertNoDiagnostics('''
+class MyConstants() {
+  static const foo = 1;
+}
+''');
+  }
+
+  Future<void>
+  test_primary_constructor_guard_with_parameters_is_not_marked() async {
+    await assertNoDiagnostics('''
+class MyConstants._(final int x) {
+  static const foo = 1;
+}
+''');
+  }
+
+  Future<void> test_primary_constructor_guard_with_body_is_not_marked() async {
+    await assertNoDiagnostics('''
+class MyConstants._() {
+  this {
+    print(1);
+  }
+
+  static const foo = 1;
+}
+''');
+  }
+
+  Future<void>
+  test_primary_constructor_guard_with_additional_constructor_is_not_marked() async {
+    await assertNoDiagnostics('''
+class MyConstants._() {
+  factory MyConstants.create() => MyConstants._();
+  static const foo = 1;
+}
+''');
+  }
 }

--- a/packages/leancode_lint/test/test_cases/prefer_abstract_final_class_test.dart
+++ b/packages/leancode_lint/test/test_cases/prefer_abstract_final_class_test.dart
@@ -292,7 +292,7 @@ class MyConstants._() {
   test_primary_constructor_guard_with_additional_constructor_is_not_marked() async {
     await assertNoDiagnostics('''
 class MyConstants._() {
-  factory MyConstants.create() => MyConstants._();
+  factory create() => MyConstants._();
   static const foo = 1;
 }
 ''');


### PR DESCRIPTION
Makes the custom lints handle Dart 3.13's primary constructors, with new test cases for every affected rule.

## Lint fixes

- **`missing_equatable_props`**: fields declared by a primary constructor's declaring parameters (`class MyState(final int a) with Equatable`) are now required in `props`, and a superclass declaring its fields in a primary constructor now triggers the `super.props` requirement (such fields report `isOriginDeclaringFormalParameter`, not `isOriginDeclaration`). The quick-fix handles both as well.
- **`constructor_parameters_and_fields_should_have_the_same_order`**: header-declared fields now participate in the field order (preceding body fields) when checking the class's other constructors. This also fixes a false positive where a factory's parameters matched the true field order but the lint only saw body fields.
- **`avoid_build_context_in_blocs`**: `BuildContext` parameters in a Bloc/Cubit's primary constructor header (plain and field-declaring) are now reported.
- **`prefer_abstract_final_class`**: a private `class MyConstants._()` primary constructor with no parameters and no `this` body is now recognized as an instantiation guard (including `class const`), and the fix removes it from the class header.
- **`convert_positional_to_named_formal` assist**: now preserves the parameter's own declaration instead of synthesizing `required this.<name>`, which corrupted a primary constructor's declaring parameters (`final int x`) and `super.x` parameters.

## Notes

- Naming lints (`add_cubit_suffix_for_cubits`, `bloc_related_class_naming`, `bloc_subclasses_naming`, `prefix_widgets_returning_slivers`) already use `namePart.typeName` and needed no changes; a primary-constructor regression test was added for `add_cubit_suffix_for_cubits`.
- Non-declaring header parameters (`int x` without `final`/`var`) are correctly not treated as fields.
- All analyzer APIs used exist at the constraint floor (analyzer 13.0.0), so no constraint bump is needed.
- Tests were verified to fail without the lint fixes (11 failures across the four rules on the old implementations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KiMgutpA35YKFfcHdXDt6E

---
_Generated by [Claude Code](https://claude.ai/code/session_01KiMgutpA35YKFfcHdXDt6E)_