### PR TITLE
Fix avoid_context_read_in_build false positive on non-widget-returning callbacks

### DIFF
--- a/packages/leancode_lint/CHANGELOG.md
+++ b/packages/leancode_lint/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-- Fix a false positive in [`avoid_context_read_in_build`](https://github.com/leancodepl/flutter_corelibrary/tree/master/packages/leancode_lint#avoid_context_read_in_build) where `context.read` inside a provider's `create` callback (e.g. `BlocProvider(create: (context) => ...)`) was flagged, even though `create` runs lazily once rather than on every rebuild.
+- Update [`avoid_context_read_in_build`](https://github.com/leancodepl/flutter_corelibrary/tree/master/packages/leancode_lint#avoid_context_read_in_build) to not report a `BuildContext`-taking closure that doesn't itself produce a `Widget` (e.g. a provider's `create` callback, such as `BlocProvider(create: (context) => ...)`), since it runs once as a lazy factory rather than on every rebuild.
 
 # 26.2.0
 

--- a/packages/leancode_lint/CHANGELOG.md
+++ b/packages/leancode_lint/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- Fix a false positive in [`avoid_context_read_in_build`](https://github.com/leancodepl/flutter_corelibrary/tree/master/packages/leancode_lint#avoid_context_read_in_build) where `context.read` inside a provider's `create` callback (e.g. `BlocProvider(create: (context) => ...)`) was flagged, even though `create` runs lazily once rather than on every rebuild.
+
 # 26.2.0
 
 - Update [`prefer_equatable_mixin`](https://github.com/leancodepl/flutter_corelibrary/tree/master/packages/leancode_lint#prefer_equatable_mixin) to suggest mixing in `Equatable` directly when the linted package depends on `equatable` 2.1.0 or higher, where `EquatableMixin` is deprecated.

--- a/packages/leancode_lint/CHANGELOG.md
+++ b/packages/leancode_lint/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-- Update [`avoid_context_read_in_build`](https://github.com/leancodepl/flutter_corelibrary/tree/master/packages/leancode_lint#avoid_context_read_in_build) to not report a `BuildContext`-taking closure that doesn't itself produce a `Widget` (e.g. a provider's `create` callback, such as `BlocProvider(create: (context) => ...)`), since it runs once as a lazy factory rather than on every rebuild.
+- Update [`avoid_context_read_in_build`](https://github.com/leancodepl/flutter_corelibrary/tree/master/packages/leancode_lint#avoid_context_read_in_build) to exempt `BuildContext`-taking closures that don't return a `Widget` (e.g. a provider's `create`), since they run once rather than on every rebuild.
 
 # 26.2.0
 

--- a/packages/leancode_lint/README.md
+++ b/packages/leancode_lint/README.md
@@ -324,10 +324,11 @@ three run on every rebuild, so none of them belong in `build`. Either consume
 the value with `watch` / `select` / `BlocBuilder` / `BlocSelector`, or move the
 read into a callback. Reads inside deferred interaction callbacks (`onTap`,
 `onPressed`) are exempt — that's where `read` is meant to be used; reads inside
-builder closures that run during `build` are checked. Reads inside a
-provider's `create` callback (e.g. `BlocProvider`, `RepositoryProvider`,
-`Provider`) are also exempt, since `create` runs lazily once rather than on
-every rebuild.
+builder closures that run during `build` are checked. A closure that takes a
+`BuildContext` but doesn't itself return a `Widget` — e.g. a provider's
+`create` callback, such as `BlocProvider(create: (context) => ...)` — is
+exempt too, since it runs once as a lazy factory rather than on every
+rebuild.
 
 **BAD:**
 

--- a/packages/leancode_lint/README.md
+++ b/packages/leancode_lint/README.md
@@ -324,11 +324,9 @@ three run on every rebuild, so none of them belong in `build`. Either consume
 the value with `watch` / `select` / `BlocBuilder` / `BlocSelector`, or move the
 read into a callback. Reads inside deferred interaction callbacks (`onTap`,
 `onPressed`) are exempt — that's where `read` is meant to be used; reads inside
-builder closures that run during `build` are checked. A closure that takes a
-`BuildContext` but doesn't itself return a `Widget` — e.g. a provider's
-`create` callback, such as `BlocProvider(create: (context) => ...)` — is
-exempt too, since it runs once as a lazy factory rather than on every
-rebuild.
+builder closures that run during `build` are checked. A `BuildContext`-taking
+closure that doesn't return a `Widget` (e.g. a provider's `create`) is exempt
+too, since it runs once rather than on every rebuild.
 
 **BAD:**
 

--- a/packages/leancode_lint/README.md
+++ b/packages/leancode_lint/README.md
@@ -324,7 +324,10 @@ three run on every rebuild, so none of them belong in `build`. Either consume
 the value with `watch` / `select` / `BlocBuilder` / `BlocSelector`, or move the
 read into a callback. Reads inside deferred interaction callbacks (`onTap`,
 `onPressed`) are exempt — that's where `read` is meant to be used; reads inside
-builder closures that run during `build` are checked.
+builder closures that run during `build` are checked. Reads inside a
+provider's `create` callback (e.g. `BlocProvider`, `RepositoryProvider`,
+`Provider`) are also exempt, since `create` runs lazily once rather than on
+every rebuild.
 
 **BAD:**
 
@@ -357,6 +360,15 @@ Widget build(BuildContext context) {
   return ElevatedButton(
     onPressed: () => context.read<CounterCubit>().increment(),
     child: const Text('+'),
+  );
+}
+```
+
+```dart
+Widget build(BuildContext context) {
+  return BlocProvider(
+    create: (context) => CounterCubit(repository: context.read()),
+    child: const CounterPage(),
   );
 }
 ```

--- a/packages/leancode_lint/lib/src/lints/avoid_context_read_in_build.dart
+++ b/packages/leancode_lint/lib/src/lints/avoid_context_read_in_build.dart
@@ -25,10 +25,11 @@ import 'package:leancode_lint/src/type_checker.dart';
 /// reference. All three run on every rebuild, so none of them belong in
 /// `build`. Reads inside deferred interaction callbacks (`onTap`, `onPressed`)
 /// are exempt — that is where `read` is meant to be used; reads inside builder
-/// closures that run during build are checked. Reads inside a provider's
-/// `create` callback (e.g. `BlocProvider`, `RepositoryProvider`, `Provider`)
-/// are exempt too, since `create` runs lazily once rather than on every
-/// rebuild.
+/// closures that run during build are checked. A closure that takes a
+/// `BuildContext` but does not itself produce a `Widget` (e.g. a provider's
+/// `create` callback, which builds a service/bloc lazily once rather than on
+/// every rebuild) is exempt too — it is not part of the render tree, so
+/// nothing re-runs it when the read value changes.
 class AvoidContextReadInBuild extends AnalysisRule {
   AvoidContextReadInBuild()
     : super(name: code.lowerCaseName, description: code.problemMessage);
@@ -63,6 +64,11 @@ class _Visitor extends SimpleAstVisitor<void> {
     packageName: 'flutter',
   );
 
+  static const _widgetChecker = TypeChecker.fromName(
+    'Widget',
+    packageName: 'flutter',
+  );
+
   @override
   void visitMethodInvocation(MethodInvocation node) {
     if (node.methodName.name != 'read') {
@@ -82,9 +88,10 @@ class _Visitor extends SimpleAstVisitor<void> {
   }
 
   /// Whether [node] executes during build: it is inside a widget's `build`
-  /// method, and every closure between [node] and that method declares a
-  /// `BuildContext` parameter (i.e. is a builder that runs during build, not a
-  /// deferred interaction callback).
+  /// method, and every closure between [node] and that method both declares a
+  /// `BuildContext` parameter and produces a `Widget` (i.e. is a builder that
+  /// runs during build, not a deferred interaction callback or a lazy factory
+  /// like a provider's `create`).
   bool _runsDuringBuild(AstNode node) {
     for (
       AstNode? current = node.parent;
@@ -92,8 +99,8 @@ class _Visitor extends SimpleAstVisitor<void> {
       current = current.parent
     ) {
       if (current is FunctionExpression &&
-          (_isProviderCreateCallback(current) ||
-              !_declaresBuildContextParameter(current))) {
+          (!_declaresBuildContextParameter(current) ||
+              !_returnsWidget(current))) {
         return false;
       }
       if (current is MethodDeclaration) {
@@ -108,29 +115,6 @@ class _Visitor extends SimpleAstVisitor<void> {
     return false;
   }
 
-  /// Whether [function] is the `create` callback of a provider-style widget
-  /// (`Provider`, `ChangeNotifierProvider`, `BlocProvider`,
-  /// `RepositoryProvider`, ...), from either package:provider or
-  /// package:flutter_bloc.
-  ///
-  /// Unlike a builder that runs on every rebuild, `create` is invoked lazily
-  /// exactly once to construct the provided value, so `read`ing inside it is
-  /// the intended, documented pattern rather than a stale-UI bug.
-  bool _isProviderCreateCallback(FunctionExpression function) {
-    final parent = function.parent;
-    if (parent is! NamedArgument || parent.name.lexeme != 'create') {
-      return false;
-    }
-    final argumentList = parent.parent;
-    if (argumentList is! ArgumentList) {
-      return false;
-    }
-    final creation = argumentList.parent;
-    return creation is InstanceCreationExpression &&
-        (creation.constructorName.type.element?.name?.contains('Provider') ??
-            false);
-  }
-
   bool _declaresBuildContextParameter(FunctionExpression function) {
     final parameters = function.parameters?.parameters;
     if (parameters == null) {
@@ -143,6 +127,19 @@ class _Visitor extends SimpleAstVisitor<void> {
       }
     }
     return false;
+  }
+
+  /// Whether [function] produces a `Widget`.
+  ///
+  /// Only widget-returning closures are re-invoked to render part of the tree
+  /// on every rebuild. A `BuildContext`-taking closure that returns something
+  /// else — a bloc, a repository, a plain value — is a factory that runs
+  /// once (e.g. a provider's `create`), not a builder, so `read`ing inside it
+  /// is the intended pattern rather than a stale-UI bug.
+  bool _returnsWidget(FunctionExpression function) {
+    final returnType = function.declaredFragment?.element.returnType;
+    return returnType != null &&
+        _widgetChecker.isAssignableFromType(returnType);
   }
 }
 

--- a/packages/leancode_lint/lib/src/lints/avoid_context_read_in_build.dart
+++ b/packages/leancode_lint/lib/src/lints/avoid_context_read_in_build.dart
@@ -125,11 +125,11 @@ class _Visitor extends SimpleAstVisitor<void> {
   /// Whether [function] returns a `Widget`. Only such closures re-run on
   /// every rebuild; anything else is a one-off factory (e.g. a provider's
   /// `create`).
-  bool _returnsWidget(FunctionExpression function) {
-    final returnType = function.declaredFragment?.element.returnType;
-    return returnType != null &&
-        _widgetChecker.isAssignableFromType(returnType);
-  }
+  bool _returnsWidget(FunctionExpression function) =>
+      switch (function.declaredFragment?.element.returnType) {
+        final returnType? => _widgetChecker.isAssignableFromType(returnType),
+        null => false,
+      };
 }
 
 class ReplaceContextReadWithWatchFix extends ResolvedCorrectionProducer {

--- a/packages/leancode_lint/lib/src/lints/avoid_context_read_in_build.dart
+++ b/packages/leancode_lint/lib/src/lints/avoid_context_read_in_build.dart
@@ -22,14 +22,10 @@ import 'package:leancode_lint/src/type_checker.dart';
 ///
 /// Every `read` that executes during build is reported, whatever it is used
 /// for: reading a value, calling a method, or grabbing a bloc/service
-/// reference. All three run on every rebuild, so none of them belong in
-/// `build`. Reads inside deferred interaction callbacks (`onTap`, `onPressed`)
-/// are exempt — that is where `read` is meant to be used; reads inside builder
-/// closures that run during build are checked. A closure that takes a
-/// `BuildContext` but does not itself produce a `Widget` (e.g. a provider's
-/// `create` callback, which builds a service/bloc lazily once rather than on
-/// every rebuild) is exempt too — it is not part of the render tree, so
-/// nothing re-runs it when the read value changes.
+/// reference. Reads inside deferred interaction callbacks (`onTap`,
+/// `onPressed`) are exempt, and so are `BuildContext`-taking closures that
+/// don't return a `Widget` (e.g. a provider's `create`), since neither runs
+/// on every rebuild.
 class AvoidContextReadInBuild extends AnalysisRule {
   AvoidContextReadInBuild()
     : super(name: code.lowerCaseName, description: code.problemMessage);
@@ -87,11 +83,8 @@ class _Visitor extends SimpleAstVisitor<void> {
     rule.reportAtNode(node.methodName);
   }
 
-  /// Whether [node] executes during build: it is inside a widget's `build`
-  /// method, and every closure between [node] and that method both declares a
-  /// `BuildContext` parameter and produces a `Widget` (i.e. is a builder that
-  /// runs during build, not a deferred interaction callback or a lazy factory
-  /// like a provider's `create`).
+  /// Whether [node] is inside a widget's `build` method, with every closure
+  /// in between taking `BuildContext` and returning a `Widget`.
   bool _runsDuringBuild(AstNode node) {
     for (
       AstNode? current = node.parent;
@@ -129,13 +122,9 @@ class _Visitor extends SimpleAstVisitor<void> {
     return false;
   }
 
-  /// Whether [function] produces a `Widget`.
-  ///
-  /// Only widget-returning closures are re-invoked to render part of the tree
-  /// on every rebuild. A `BuildContext`-taking closure that returns something
-  /// else — a bloc, a repository, a plain value — is a factory that runs
-  /// once (e.g. a provider's `create`), not a builder, so `read`ing inside it
-  /// is the intended pattern rather than a stale-UI bug.
+  /// Whether [function] returns a `Widget`. Only such closures re-run on
+  /// every rebuild; anything else is a one-off factory (e.g. a provider's
+  /// `create`).
   bool _returnsWidget(FunctionExpression function) {
     final returnType = function.declaredFragment?.element.returnType;
     return returnType != null &&

--- a/packages/leancode_lint/lib/src/lints/avoid_context_read_in_build.dart
+++ b/packages/leancode_lint/lib/src/lints/avoid_context_read_in_build.dart
@@ -25,7 +25,10 @@ import 'package:leancode_lint/src/type_checker.dart';
 /// reference. All three run on every rebuild, so none of them belong in
 /// `build`. Reads inside deferred interaction callbacks (`onTap`, `onPressed`)
 /// are exempt — that is where `read` is meant to be used; reads inside builder
-/// closures that run during build are checked.
+/// closures that run during build are checked. Reads inside a provider's
+/// `create` callback (e.g. `BlocProvider`, `RepositoryProvider`, `Provider`)
+/// are exempt too, since `create` runs lazily once rather than on every
+/// rebuild.
 class AvoidContextReadInBuild extends AnalysisRule {
   AvoidContextReadInBuild()
     : super(name: code.lowerCaseName, description: code.problemMessage);
@@ -89,7 +92,8 @@ class _Visitor extends SimpleAstVisitor<void> {
       current = current.parent
     ) {
       if (current is FunctionExpression &&
-          !_declaresBuildContextParameter(current)) {
+          (_isProviderCreateCallback(current) ||
+              !_declaresBuildContextParameter(current))) {
         return false;
       }
       if (current is MethodDeclaration) {
@@ -102,6 +106,29 @@ class _Visitor extends SimpleAstVisitor<void> {
       }
     }
     return false;
+  }
+
+  /// Whether [function] is the `create` callback of a provider-style widget
+  /// (`Provider`, `ChangeNotifierProvider`, `BlocProvider`,
+  /// `RepositoryProvider`, ...), from either package:provider or
+  /// package:flutter_bloc.
+  ///
+  /// Unlike a builder that runs on every rebuild, `create` is invoked lazily
+  /// exactly once to construct the provided value, so `read`ing inside it is
+  /// the intended, documented pattern rather than a stale-UI bug.
+  bool _isProviderCreateCallback(FunctionExpression function) {
+    final parent = function.parent;
+    if (parent is! NamedArgument || parent.name.lexeme != 'create') {
+      return false;
+    }
+    final argumentList = parent.parent;
+    if (argumentList is! ArgumentList) {
+      return false;
+    }
+    final creation = argumentList.parent;
+    return creation is InstanceCreationExpression &&
+        (creation.constructorName.type.element?.name?.contains('Provider') ??
+            false);
   }
 
   bool _declaresBuildContextParameter(FunctionExpression function) {

--- a/packages/leancode_lint/test/mock_libraries/flutter_bloc.dart
+++ b/packages/leancode_lint/test/mock_libraries/flutter_bloc.dart
@@ -4,6 +4,7 @@ mixin MockFlutterBloc on AnalysisRuleTest {
   @override
   void setUp() {
     newPackage('flutter_bloc').addFile('lib/flutter_bloc.dart', '''
+import 'package:bloc/bloc.dart';
 import 'package:flutter/material.dart';
 
 export 'package:bloc/bloc.dart';
@@ -12,6 +13,12 @@ extension BlocContextExtention on BuildContext {
   T read<T>() => throw UnimplementedError();
 
   T watch<T>() => throw UnimplementedError();
+}
+
+class BlocProvider<T extends BlocBase<Object?>> extends Widget {
+  const BlocProvider({super.key, required this.create, this.child});
+  final T Function(BuildContext context) create;
+  final Widget? child;
 }
 ''');
     super.setUp();

--- a/packages/leancode_lint/test/test_cases/avoid_context_read_in_build_test.dart
+++ b/packages/leancode_lint/test/test_cases/avoid_context_read_in_build_test.dart
@@ -39,6 +39,25 @@ class Button extends StatelessWidget {
   Widget build(BuildContext context) => const SizedBox();
 }
 
+/// A widget-agnostic stand-in for lazy, non-widget-returning factories such as
+/// a provider's `create`: it takes a `BuildContext`-accepting callback under
+/// an arbitrary name and does not itself return a `Widget`.
+class Factory extends StatelessWidget {
+  const Factory({super.key, required this.make});
+  final Object Function(BuildContext context) make;
+  @override
+  Widget build(BuildContext context) => const SizedBox();
+}
+
+/// Same shape as [Factory], but its callback returns a `Widget` — i.e. it is
+/// a builder in disguise, under a name that isn't `builder`/`create`.
+class WidgetFactory extends StatelessWidget {
+  const WidgetFactory({super.key, required this.make});
+  final Widget Function(BuildContext context) make;
+  @override
+  Widget build(BuildContext context) => const SizedBox();
+}
+
 class MyWidget extends StatelessWidget {
   const MyWidget({super.key});
 
@@ -150,6 +169,28 @@ class AvoidContextReadInBuildTest extends AnalysisRuleTest
         return MyCubit();
       },
       child: const SizedBox(),
+    );'''),
+    );
+  }
+
+  /// The exemption is about the callback's return type, not its parameter
+  /// name or the enclosing widget's name: any `BuildContext`-taking closure
+  /// that doesn't produce a `Widget` is a one-off factory, not a builder.
+  Future<void> test_nonWidgetReturningCallback_arbitraryName_ok() async {
+    await assertNoDiagnostics(
+      _widget('''
+    return Factory(make: (context) => context.read<MyService>());'''),
+    );
+  }
+
+  /// Conversely, a `Widget`-returning callback is still checked even when
+  /// it's neither named `builder`/`create` nor declared on a widget with
+  /// "Provider" in its name.
+  Future<void> test_widgetReturningCallback_arbitraryName_flagged() async {
+    await assertDiagnosticsInRanges(
+      _widget('''
+    return WidgetFactory(
+      make: (context) => Consumer(value: context.[!read!]<MyCubit>().state),
     );'''),
     );
   }

--- a/packages/leancode_lint/test/test_cases/avoid_context_read_in_build_test.dart
+++ b/packages/leancode_lint/test/test_cases/avoid_context_read_in_build_test.dart
@@ -39,9 +39,8 @@ class Button extends StatelessWidget {
   Widget build(BuildContext context) => const SizedBox();
 }
 
-/// A widget-agnostic stand-in for lazy, non-widget-returning factories such as
-/// a provider's `create`: it takes a `BuildContext`-accepting callback under
-/// an arbitrary name and does not itself return a `Widget`.
+/// A non-widget-returning callback under an arbitrary name, e.g. a
+/// provider's `create`.
 class Factory extends StatelessWidget {
   const Factory({super.key, required this.make});
   final Object Function(BuildContext context) make;
@@ -49,8 +48,7 @@ class Factory extends StatelessWidget {
   Widget build(BuildContext context) => const SizedBox();
 }
 
-/// Same shape as [Factory], but its callback returns a `Widget` — i.e. it is
-/// a builder in disguise, under a name that isn't `builder`/`create`.
+/// Same as [Factory], but the callback returns a `Widget`.
 class WidgetFactory extends StatelessWidget {
   const WidgetFactory({super.key, required this.make});
   final Widget Function(BuildContext context) make;
@@ -158,8 +156,6 @@ class AvoidContextReadInBuildTest extends AnalysisRuleTest
     );
   }
 
-  /// `create` is invoked lazily, once, to construct the provided value — not
-  /// on every rebuild — so `read`ing inside it is the intended pattern.
   Future<void> test_providerCreateCallback_ok() async {
     await assertNoDiagnostics(
       _widget('''
@@ -173,9 +169,7 @@ class AvoidContextReadInBuildTest extends AnalysisRuleTest
     );
   }
 
-  /// The exemption is about the callback's return type, not its parameter
-  /// name or the enclosing widget's name: any `BuildContext`-taking closure
-  /// that doesn't produce a `Widget` is a one-off factory, not a builder.
+  /// Exemption tracks return type, not the callback's name.
   Future<void> test_nonWidgetReturningCallback_arbitraryName_ok() async {
     await assertNoDiagnostics(
       _widget('''
@@ -183,9 +177,7 @@ class AvoidContextReadInBuildTest extends AnalysisRuleTest
     );
   }
 
-  /// Conversely, a `Widget`-returning callback is still checked even when
-  /// it's neither named `builder`/`create` nor declared on a widget with
-  /// "Provider" in its name.
+  /// Still flagged regardless of the callback's name.
   Future<void> test_widgetReturningCallback_arbitraryName_flagged() async {
     await assertDiagnosticsInRanges(
       _widget('''

--- a/packages/leancode_lint/test/test_cases/avoid_context_read_in_build_test.dart
+++ b/packages/leancode_lint/test/test_cases/avoid_context_read_in_build_test.dart
@@ -139,6 +139,21 @@ class AvoidContextReadInBuildTest extends AnalysisRuleTest
     );
   }
 
+  /// `create` is invoked lazily, once, to construct the provided value — not
+  /// on every rebuild — so `read`ing inside it is the intended pattern.
+  Future<void> test_providerCreateCallback_ok() async {
+    await assertNoDiagnostics(
+      _widget('''
+    return BlocProvider(
+      create: (context) {
+        final s = context.read<MyService>();
+        return MyCubit();
+      },
+      child: const SizedBox(),
+    );'''),
+    );
+  }
+
   Future<void> test_watch_ok() async {
     await assertNoDiagnostics(
       _widget('''


### PR DESCRIPTION
## Summary

- `avoid_context_read_in_build` was flagging `context.read` inside a provider's `create` callback (e.g. `BlocProvider(create: (context) => MyCubit(repo: context.read()))`), even though `create` runs lazily once rather than on every rebuild.
- A `BuildContext`-taking closure is now only treated as running during build if it also returns a `Widget`. Non-widget-returning closures (a provider's `create`, or any other lazy factory) are exempt regardless of the callback's name or the enclosing widget's name.

## Test plan

- [x] `dart test` on `packages/leancode_lint` — 253/253 passing
- [x] `dart analyze` — no issues
- [x] `dart format --set-exit-if-changed` — no changes needed
- [x] Added tests covering the original false positive and confirming the exemption tracks return type, not naming conventions


---
_Generated by [Claude Code](https://claude.ai/code/session_01FadFXZpP7Bzd3yPQwNorQZ)_