### PR TITLE
[leancode_debug_page] Don't open a second debug page when one is already open

### DIFF
--- a/packages/leancode_debug_page/CHANGELOG.md
+++ b/packages/leancode_debug_page/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.1.5
+
+- Fix opening a second debug page when one is already open
+
 ## 3.1.4
 
 - Fix garbled non-ASCII characters in logged response bodies

--- a/packages/leancode_debug_page/example/pubspec.lock
+++ b/packages/leancode_debug_page/example/pubspec.lock
@@ -174,7 +174,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "3.1.4"
+    version: "3.1.5"
   lints:
     dependency: transitive
     description:

--- a/packages/leancode_debug_page/lib/src/core/debug_page_controller.dart
+++ b/packages/leancode_debug_page/lib/src/core/debug_page_controller.dart
@@ -85,7 +85,13 @@ class DebugPageController {
     _loggerLogController.add(filtered);
   }
 
-  void open() => navigatorKey.currentState!.push(LogsInspectorRoute(this));
+  void open() {
+    if (_isOpen.value) {
+      return;
+    }
+
+    navigatorKey.currentState!.push(LogsInspectorRoute(this));
+  }
 
   void close() =>
       navigatorKey.currentState!.popUntil((route) => route is! DebugPageRoute);

--- a/packages/leancode_debug_page/pubspec.yaml
+++ b/packages/leancode_debug_page/pubspec.yaml
@@ -1,5 +1,5 @@
 name: leancode_debug_page
-version: 3.1.4
+version: 3.1.5
 homepage: https://github.com/leancodepl/flutter_corelibrary/tree/master/packages/leancode_debug_page
 repository: https://github.com/leancodepl/flutter_corelibrary
 description: >-

--- a/packages/leancode_debug_page/test/debug_page_controller/debug_page_controller_open_test.dart
+++ b/packages/leancode_debug_page/test/debug_page_controller/debug_page_controller_open_test.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:leancode_debug_page/src/core/debug_page_controller.dart';
+import 'package:leancode_debug_page/src/core/logging_http_client.dart';
+import 'package:leancode_debug_page/src/ui/logs_inspector/logs_inspector.dart';
+
+import '../util/mock_http_client.dart';
+
+void main() {
+  group('DebugPageController - open:', () {
+    late DebugPageController controller;
+    late GlobalKey<NavigatorState> navigatorKey;
+
+    setUp(() {
+      navigatorKey = GlobalKey();
+      controller = DebugPageController(
+        loggingHttpClient: LoggingHttpClient(client: MockHttpClient()),
+        showOnShake: false,
+        navigatorKey: navigatorKey,
+      );
+    });
+
+    tearDown(() => controller.dispose());
+
+    Future<void> pumpApp(WidgetTester tester) => tester.pumpWidget(
+      MaterialApp(
+        navigatorKey: navigatorKey,
+        navigatorObservers: [controller.navigatorObserver],
+        home: const Scaffold(),
+      ),
+    );
+
+    testWidgets('does not open a second debug page when one is already open', (
+      tester,
+    ) async {
+      await pumpApp(tester);
+
+      controller.open();
+      await tester.pumpAndSettle();
+
+      expect(controller.isOpen.value, isTrue);
+      expect(find.byType(LogsInspector), findsOneWidget);
+
+      controller.open();
+      await tester.pumpAndSettle();
+
+      expect(find.byType(LogsInspector), findsOneWidget);
+
+      // A single pop leaves no debug page behind.
+      navigatorKey.currentState!.pop();
+      await tester.pumpAndSettle();
+
+      expect(controller.isOpen.value, isFalse);
+      expect(find.byType(LogsInspector), findsNothing);
+    });
+
+    testWidgets('can be reopened after being closed', (tester) async {
+      await pumpApp(tester);
+
+      controller.open();
+      await tester.pumpAndSettle();
+      controller.close();
+      await tester.pumpAndSettle();
+
+      controller.open();
+      await tester.pumpAndSettle();
+
+      expect(controller.isOpen.value, isTrue);
+      expect(find.byType(LogsInspector), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
DebugPageController.open() pushed a new LogsInspectorRoute unconditionally,
so a shake (or a second entry-button tap racing the route transition) while
the debug page was already showing stacked another copy on top of it. The
controller already tracks whether a debug page route is live via its
navigator observer, so open() now bails out when isOpen is true.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RfoX5s7Embr9hnLSzbQKRE